### PR TITLE
(SIMP-482) Updated to support inline hieradata

### DIFF
--- a/lib/simp/beaker_helpers.rb
+++ b/lib/simp/beaker_helpers.rb
@@ -1,7 +1,7 @@
 module Simp; end
 
 module Simp::BeakerHelpers
-  VERSION = '1.0.1'
+  VERSION = '1.0.2'
 
   # Locates .fixture.yml in or above this directory.
   def fixtures_yml_path
@@ -143,5 +143,70 @@ module Simp::BeakerHelpers
     on ca_sut, "rm -rf #{modulepath.first}/pki/files/keydist/*"
     on ca_sut, "cp -a /root/pki/keydist/ #{modulepath.first}/pki/files/"
     on ca_sut, "chgrp -R puppet #{modulepath.first}/pki/files/keydist"
+  end
+
+  ## Inline Hiera Helpers ##
+  ## These will be integrated into core Beaker at some point ##
+
+  # Set things up for the inline hieradata functions 'set_hieradata_on'
+  # and 'clear_temp_hieradata'
+  #
+  #
+  require 'rspec'
+  RSpec.configure do |c|
+    c.before(:all) do
+      @temp_hieradata_dirs = @temp_hieradata_dirs || []
+    end
+
+    c.after(:all) do
+      clear_temp_hieradata
+    end
+  end
+
+  # Set the hiera data file on the provided host to the passed data structure
+  #
+  # Note: This is authoritative, you cannot mix this with other hieradata copies
+  #
+  # @param[Host, Array<Host>, String, Symbol] One or more hosts to act upon.
+  #
+  # @param[Hieradata, Hash] The full hiera data structure to write to the system.
+  #
+  # @param[Data_file, String] The filename (not path) of the hiera data
+  #                           YAML file to write to the system.
+  #
+  # @param[Hiera_config, Array<String>] The hiera config array to write
+  #                                     to the system. Must contain the
+  #                                     Data_file name as one element.
+  def set_hieradata_on(host, hieradata, data_file='default')
+    # Keep a record of all temporary directories that are created
+    #
+    # Should be cleaned by calling `clear_temp_hiera data` in after(:all)
+    #
+    # Omit this call to be able to delve into the hiera data that is
+    # being created
+    @temp_hieradata_dirs = @temp_hieradata_dirs || []
+
+    data_dir = Dir.mktmpdir('hieradata')
+    @temp_hieradata_dirs << data_dir
+
+    fh = File.open(File.join(data_dir,"#{data_file}.yaml"),'w')
+    fh.puts(hieradata.to_yaml)
+    fh.close
+
+    copy_hiera_data_to(host, data_dir)
+    write_hiera_config_on(host, Array(data_file))
+  end
+
+  # Clean up all temporary hiera data files.
+  #
+  # Meant to be called from after(:all)
+  def clear_temp_hieradata
+    if @temp_hieradata_dirs && !@temp_hieradata_dirs.empty?
+      @temp_hieradata_dirs.each do |data_dir|
+        if File.exists?(data_dir)
+          FileUtils.rm_r(data_dir)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This patch supports adding inline hieradata to your Beaker tests.

I'm attempting to push this into Beaker core but haven't gotten the spec
tests completely working yet.

Once in Beaker core, it should be removed from here.

SIMP-482 #close #comment Support inline hieradata