### PR TITLE
(SIMP-492) disable stringify_facts on all SUTs

### DIFF
--- a/lib/simp/beaker_helpers.rb
+++ b/lib/simp/beaker_helpers.rb
@@ -68,6 +68,11 @@ module Simp::BeakerHelpers
 
   # Apply known OS fixes we need to run Beaker on each SUT
   def fix_errata_on( suts = hosts )
+    # SIMP uses structured facts, therefore stringify_facts must be disabled
+    unless ENV['BEAKER_stringify_facts'] == 'yes'
+      on suts, 'puppet config set stringify_facts false'
+    end
+
     suts.each do |sut|
       # net-tools required for netstat utility being used by be_listening
       if fact_on(sut, 'osfamily') == 'RedHat' && fact_on(sut, 'operatingsystemmajrelease') == '7'


### PR DESCRIPTION
SIMP uses structured facts, therefore stringify_facts must be disabled
on all SUTs.  This patch modifies the `fix_errata_on` method to set the
Puppet config key `stringify_facts` to `false` on all SUTs.

SIMP-492 #close #comment `fix_errata_on(suts)` disables stringify_facts