### PR TITLE
(SIMP-510) Make pki_copy add 'pki/' like pki::copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,14 +77,15 @@ Copy a single SUT's PKI certs (with cacerts) onto an SUT.  This simulates the re
 
 The directory structure copied to the SUT is:
 ```
-  HOST_PKI_DIR/
-          cacerts/cacerts.pem
-          public/fdqn.pub
-          private/fdqn.pem
+  SUT_BASE_DIR/
+              pki/
+                  cacerts/cacerts.pem
+                  public/fdqn.pub
+                  private/fdqn.pem
 
 ```
 
-`copy_pki_to(sut, local_pki_dir, sut_pki_dir = '/etc/pki/simp-testing')`
+`copy_pki_to(sut, local_pki_dir, sut_base_dir = '/etc/pki/simp-testing')`
 
 
 #### `copy_keydist_to`

--- a/lib/simp/beaker_helpers.rb
+++ b/lib/simp/beaker_helpers.rb
@@ -1,7 +1,7 @@
 module Simp; end
 
 module Simp::BeakerHelpers
-  VERSION = '1.0.3'
+  VERSION = '1.0.4'
 
   # Locates .fixture.yml in or above this directory.
   def fixtures_yml_path
@@ -175,19 +175,21 @@ DEFAULT_KERNEL_TITLE=`/sbin/grubby --info=\\\${DEFAULT_KERNEL_INFO} | grep -m1 t
   #
   # The directory structure is:
   #
-  # HOST_PKI_DIR/
-  #         cacerts/cacerts.pem
-  #         public/fdqn.pub
-  #         private/fdqn.pem
-  def copy_pki_to(sut, local_pki_dir, sut_pki_dir = '/etc/pki/simp-testing')
-      fqdn = fact_on(sut, 'fqdn')
-      local_host_pki_tree   = File.join(local_pki_dir,'pki','keydist',fqdn)
-      ###local_cacert_pki_tree = File.join(local_pki_dir,'pki','keydist','cacerts')
+  # SUT_BASE_DIR/
+  #             pki/
+  #                 cacerts/cacerts.pem
+  #                 public/fdqn.pub
+  #                 private/fdqn.pem
+  def copy_pki_to(sut, local_pki_dir, sut_base_dir = '/etc/pki/simp-testing')
+      fqdn                = fact_on(sut, 'fqdn')
+      sut_pki_dir         = File.join( sut_base_dir, 'pki' )
+      local_host_pki_tree = File.join(local_pki_dir,'pki','keydist',fqdn)
       local_cacert = File.join(local_pki_dir,'pki','demoCA','cacert.pem')
+
       on sut, %Q(mkdir -p "#{sut_pki_dir}/public" "#{sut_pki_dir}/private" "#{sut_pki_dir}/cacerts")
       scp_to(sut, "#{local_host_pki_tree}/#{fqdn}.pem",   "#{sut_pki_dir}/private/")
       scp_to(sut, "#{local_host_pki_tree}/#{fqdn}.pub",   "#{sut_pki_dir}/public/")
-      ###scp_to(sut, local_cacert_pki_tree, sut_pki_dir)
+
       # NOTE: to match pki::copy, 'cacert.pem' is renamed to 'cacerts.pem'
       scp_to(sut, local_cacert, "#{sut_pki_dir}/cacerts/cacerts.pem")
   end


### PR DESCRIPTION
Before this commit, the `pki_copy` method would scp a PKI cert tree
into the `sut_pki_dir` directory.  This differs from the behavior of
`pki::copy`, which takes a base path, creates a `pki/` subdirectory
underneath it and copies a PKI cert tree under `pki/`.

Since `pki_copy` is intended to simulate `pki::copy`, it has been
updated to also add a `pki/` directory to the `sut_base_dir` before
copying the PKI cert tree.

SIMP-508 #close #comment Made pki_copy add 'pki/' like pki::copy