### PR TITLE
(SIMP-482) Add fix to remove target hieradata

### DIFF
--- a/lib/simp/beaker_helpers.rb
+++ b/lib/simp/beaker_helpers.rb
@@ -253,6 +253,14 @@ DEFAULT_KERNEL_TITLE=`/sbin/grubby --info=\\\${DEFAULT_KERNEL_INFO} | grep -m1 t
     fh.puts(hieradata.to_yaml)
     fh.close
 
+    # If there is already a directory on the system, the SCP below will
+    # add the local directory to the existing directory instead of
+    # replacing the contents.
+    apply_manifest_on(
+      host,
+      "file { '#{hiera_datadir(host)}': ensure => 'absent', force => true, recurse => true }"
+    ) 
+
     copy_hiera_data_to(host, data_dir)
     write_hiera_config_on(host, Array(data_file))
   end


### PR DESCRIPTION
This adds a fix to remove the hieradata directory on the remote host
prior to copying in a new one.

This works around an issue in Beaker where it will copy the directory
directly into the existing hieradata directory.

SIMP-482 #comment Work around Beaker bug