### PR TITLE
(SIMP-555) Added a task for specific nodeset run

### DIFF
--- a/lib/simp/beaker_helpers.rb
+++ b/lib/simp/beaker_helpers.rb
@@ -1,7 +1,7 @@
 module Simp; end
 
 module Simp::BeakerHelpers
-  VERSION = '1.0.5'
+  VERSION = '1.0.6'
 
   # Locates .fixture.yml in or above this directory.
   def fixtures_yml_path

--- a/lib/simp/rake/beaker.rb
+++ b/lib/simp/rake/beaker.rb
@@ -1,0 +1,50 @@
+require 'rake'
+require 'rake/clean'
+require 'rake/tasklib'
+require 'fileutils'
+require 'puppetlabs_spec_helper/rake_tasks'
+
+module Simp; end
+module Simp::Rake
+  class Beaker < ::Rake::TaskLib
+    def initialize(base_dir)
+
+      @base_dir   = base_dir
+      @clean_list = []
+
+      ::CLEAN.include( %{#{@base_dir}/log} )
+      ::CLEAN.include( %{#{@base_dir}/junit} )
+
+      yield self if block_given?
+
+      ::CLEAN.include( @clean_list )
+
+      namespace :beaker do
+        desc <<-EOM
+        Run a Beaker test against a specific Nodeset
+          * :nodeset - The nodeset against which you wish to run
+        EOM
+        task :run, [:nodeset] do |t,args|
+          fail "You must pass :nodeset to #{t}" unless args[:nodeset]
+          nodeset = args[:nodeset].strip
+        
+          old_stdout = $stdout
+          nodesets = StringIO.new
+          $stdout = nodesets
+        
+          Rake::Task['beaker_nodes'].invoke
+        
+          $stdout = old_stdout
+        
+          nodesets = nodesets.string.split("\n")
+        
+          fail "Nodeset '#{nodeset}' not found. Valid Nodesets:\n#{nodesets.map{|x| x = %(  * #{x})}.join(%(\n))}" unless nodesets.include?(nodeset)
+        
+          ENV['BEAKER_set'] = nodeset
+        
+          Rake::Task['beaker'].invoke
+        end
+      end
+    end
+  end
+end

--- a/simp-beaker-helpers.gemspec
+++ b/simp-beaker-helpers.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   EOF
   s.version     = Simp::BeakerHelpers::VERSION
   s.license     = 'Apache-2.0'
-  s.authors     = ['Chris Tessmer']
+  s.authors     = ['Chris Tessmer','Trevor Vaughan']
   s.email       = 'simp@simp-project.org'
   s.homepage    = 'https://github.com/simp/rubygem-simp-beaker-helpers'
   s.metadata = {


### PR DESCRIPTION
This adds some Rake helpers for Beaker that allow you to run a specific
nodeset. The available nodeset list is printed if an invalid entry is
made.

SIMP-555 #close