### PR TITLE
(SIMP-556) Updateds to work with FIPS mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,9 @@ gem 'simp-beaker-helpers'
 
 Add this to your project's `spec/spec_helper_acceptance.rb`:
 ```ruby
-require 'simp-beaker-helpers'
-include SIMP::BeakerHelpers
+require 'simp/beaker_helpers'
+include Simp::BeakerHelpers
 ```
-
-
 
 ## Methods
 


### PR DESCRIPTION
Updated the FIPS code to work in full enforcing mode. This includes
setting the keylength and cipher for Puppet as well as the ciphers for
SSH.

Also added a yum clean all to ensure that the tests start with a clean
YUM cache.

SIMP-556 #comment Beaker helpers updates for FIPS

Change-Id: Id072744245184c359c45a24c18662113ebeb309f