### PR TITLE
(SIMP-569) Add method pfacter_on()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 Gemfile.lock
 .bundle/
 *.old
+.vagrant
+/log

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,10 @@
-# Allow a comma or space-delimited list of gem servers
-if simp_gem_server =  ENV.fetch( 'SIMP_GEM_SERVERS', 'https://rubygems.org' )
-  simp_gem_server.split( / |,/ ).each{ |gem_server|
-    source gem_server
-  }
-end
+# Variables:
+#
+# SIMP_GEM_SERVERS | a space/comma delimited list of rubygem servers
+# PUPPET_VERSION   | specifies the version of the puppet gem to load
+puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : ['~>3']
+gem_sources   = ENV.key?('SIMP_GEM_SERVERS') ? ENV['SIMP_GEM_SERVERS'].split(/[, ]+/) : ['https://rubygems.org']
+gem_sources.each { |gem_source| source gem_source }
 
 # read dependencies in from the gemspec
 gemspec
@@ -11,9 +12,6 @@ gemspec
 # mandatory gems
 gem 'bundler'
 gem 'rake'
-gem 'puppetlabs_spec_helper'
-gem 'puppet'
-
 
 group :system_tests do
   gem 'pry'
@@ -22,4 +20,7 @@ group :system_tests do
   # NOTE: Workaround because net-ssh 2.10 is busting beaker
   # lib/ruby/1.9.1/socket.rb:251:in `tcp': wrong number of arguments (5 for 4) (ArgumentError)
   gem 'net-ssh', '~> 2.9.0'
+  gem 'puppetlabs_spec_helper'
+  gem 'puppet', puppetversion
+
 end

--- a/README.md
+++ b/README.md
@@ -9,12 +9,16 @@ Methods to assist beaker acceptance tests for SIMP.
 3. [Methods](#methods)
     * [`copy_fixture_modules_to`](#copy_fixture_modules_to)
     * [`fix_errata_on`](#fix_errata_on)
-    * [`run_fake_pki_ca_on`](#run_fake_pki_ca_on)
-    * [`copy_pki_to`](#copy_pki_to)
-    * [`copy_keydist_to`](#copy_keydist_to)
-    * [`pluginsync_on`](#pluginsync_on)
-    * [`set_hieradata_on`](#set_hieradata_on)
-    * [`clear_temp_hieradata`](#clear_temp_hieradata)
+    * PKI
+      * [`run_fake_pki_ca_on`](#run_fake_pki_ca_on)
+      * [`copy_pki_to`](#copy_pki_to)
+      * [`copy_keydist_to`](#copy_keydist_to)
+    * Custom facts
+      * [`pfact_on`](#pfact_on)
+      * [`pluginsync_on`](#pluginsync_on)
+    * Hiera
+      * [`set_hieradata_on`](#set_hieradata_on)
+      * [`clear_temp_hieradata`](#clear_temp_hieradata)
 4. [Environment variables](#environment-variables)
     * [`BEAKER_fips`](#beaker_fips)
     * [`BEAKER_spec_prep`](#beaker_spec_prep)
@@ -48,6 +52,7 @@ include Simp::BeakerHelpers
 
 Copies the local fixture modules (under `spec/fixtures/modules`) onto a list of SUTs
 `copy_fixture_modules_to( suts = hosts )`
+
 
 
 #### `fix_errata_on`
@@ -94,6 +99,13 @@ Copy a CA keydist/ directory of CA+host certs into an SUT
 This simulates the output of FakeCA's `gencerts_nopass.sh` into `keydist/` and is useful for constructing a Puppet master SUT that will distribute PKI keys via agent runs.
 
 `copy_keydist_to( ca_sut = master )`
+
+
+#### `pfact_on`
+
+Look up a face on a given SUT's using the `puppet fact` face.  This honors whatever facter-related settings the SUT's Puppet has been configured to use (i.e., `factpath`, `stringify_facts`, etc).
+
+`pfact_on( sut, fact_name )`
 
 
 #### `pluginsync_on`

--- a/Rakefile
+++ b/Rakefile
@@ -46,12 +46,6 @@ SIMP_RPM_BUILD     when set, alters the gem produced by pkg:gem to be RPM-safe.
   }
 end
 
-#desc 'run all RSpec tests'
-#task :spec do
-#  Dir.chdir @rakefile_dir
-#  sh 'bundle exec rspec spec'
-#end
-
 desc %q{run all RSpec tests (alias of 'spec')}
 task :test => :spec
 

--- a/lib/simp/beaker_helpers.rb
+++ b/lib/simp/beaker_helpers.rb
@@ -3,6 +3,14 @@ module Simp; end
 module Simp::BeakerHelpers
   VERSION = '1.0.10'
 
+  # use the `puppet fact` face to look up facts on an SUT
+  def pfact_on(sut, fact_name)
+    facts_json = on(sut,'puppet facts find xxx').output
+    facts      = JSON.parse(facts_json).fetch( 'values' )
+    facts.fetch(fact_name)
+  end
+
+
   # Locates .fixture.yml in or above this directory.
   def fixtures_yml_path
     STDERR.puts '  ** fixtures_yml_path' if ENV['BEAKER_helpers_verbose']

--- a/spec/acceptance/pfacter_spec.rb
+++ b/spec/acceptance/pfacter_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper_acceptance'
+
+context 'pfact_on operations' do
+  before(:all) do
+    copy_fixture_modules_to( hosts )
+    pluginsync_on( [master] )
+  end
+
+  describe "pfact_on(master,'root_home')" do
+    it 'should return value of root_home' do
+      expect( pfact_on(master, 'root_home')).to_not be_nil
+    end
+  end
+end

--- a/spec/acceptance/pki_tests_spec.rb
+++ b/spec/acceptance/pki_tests_spec.rb
@@ -3,8 +3,6 @@ require 'tmpdir'
 
 
 context 'PKI operations' do
-#test_name 'SIMP beaker helper PKI operations'
-begin
 
   context 'after run_fake_pki_ca_on(master,hosts)' do
     before(:all) do
@@ -64,7 +62,4 @@ begin
     end
   end
 
-rescue Exception => e
-  require 'pry'; binding.pry
-end
 end


### PR DESCRIPTION
This commit provides a new method `pfacter_on(sut,fact_name)` that
queries facts using the SUT's `puppet fact` face.  This has some
advantages over the BEAKER DSL's `facter_on` method:

  - It honors the SUT's Puppet conf (e.g.,`factpath`,`stringify_facts`)
  - The results (parsed from JSON) preserve facts' data structures

SIMP-569 #comment Bumped simp-beaker-helpers gem version to 1.0.10
SIMP-569 #close #comment Added pfacter_on() method for custom facts

Change-Id: Iaa982a6d9504c9a3ecb2a1b1758209e3761c0491