### PR TITLE
(SIMP-650) Ensure host_hash items

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,6 @@
 language: ruby
 cache: bundler
 
-# to provide the cracklib-check
-sudo: required
-before_install:
-    - sudo apt-get update -qq
-    - sudo apt-get install -y libcrack2
-
 rvm:
   - 1.9.3
   - 2.0.0


### PR DESCRIPTION
- `set_hieradata_on` accepts Strings (Hashes are still accepted)
- `BEAKER_copy_fixtures=no` prevents the module-copying phase of init
- `fix_errata` ensures that default OS host_hash items are present
- This change bumps the gem release version up to 1.0.11

SIMP-650 #close