### PR TITLE
(SIMP-729) Update to move 'yum clean' into EL only

### DIFF
--- a/lib/simp/beaker_helpers.rb
+++ b/lib/simp/beaker_helpers.rb
@@ -1,7 +1,7 @@
 module Simp; end
 
 module Simp::BeakerHelpers
-  VERSION = '1.0.11'
+  VERSION = '1.0.12'
 
   # use the `puppet fact` face to look up facts on an SUT
   def pfact_on(sut, fact_name)
@@ -180,17 +180,16 @@ DEFAULT_KERNEL_TITLE=`/sbin/grubby --info=\\\${DEFAULT_KERNEL_INFO} | grep -m1 t
           EOS
           apply_manifest_on(sut, pp, :catch_failures => false)
         end
-      end
 
+        # Clean up YUM prior to starting our test runs.
+        on(sut, 'yum clean all')
+      end
     end
 
     # Configure and reboot SUTs into FIPS mode
     unless ENV['BEAKER_fips'] == 'no'
       enable_fips_mode_on(suts)
     end
-
-    # Clean up YUM prior to starting our test runs.
-    on(suts, 'yum clean all')
   end
 
 


### PR DESCRIPTION
The 'yum clean all' statement was in the global section and broke
running with the helpers on Ubuntu systems.

SIMP-729 #comment Bug discovery and fix