### PR TITLE
Fix default module path for copy_fixtures_to

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,18 @@ include Simp::BeakerHelpers
 #### `copy_fixture_modules_to`
 
 Copies the local fixture modules (under `spec/fixtures/modules`) onto a list of SUTs
-`copy_fixture_modules_to( suts = hosts )`
+```ruby
+copy_fixture_modules_to( suts = hosts, opts = {:pluginsync => true,
+                                               :target_module_dir => '/etc/puppetlabs/code/modules'} )
+```
 
+If you need to use a non-default module path:
 
+```ruby
+copy_fixture_modules_to( hosts, {
+   :target_module_dir => '/path/to/my/modules',
+})
+```
 
 #### `fix_errata_on`
 

--- a/lib/simp/beaker_helpers.rb
+++ b/lib/simp/beaker_helpers.rb
@@ -71,7 +71,13 @@ module Simp::BeakerHelpers
 
 
   # Copy the local fixture modules (under `spec/fixtures/modules`) onto each SUT
-  def copy_fixture_modules_to( suts = hosts, pluginsync = true )
+  def copy_fixture_modules_to( suts = hosts, opts = {:pluginsync => true,
+                                                     :target_module_path => '/etc/puppetlabs/code/modules'} )
+
+    # FIXME: As a result of BKR-723, which does not look easy to fix, we cannot rely on copy_module_to()
+    # choosing a sane default for target_module_path.  In the event that BKR-723 is fixed, then the default
+    # specified here should be removed.
+
     STDERR.puts '  ** copy_fixture_modules_to' if ENV['BEAKER_helpers_verbose']
     ensure_fixture_modules
 
@@ -83,7 +89,9 @@ module Simp::BeakerHelpers
           pupmods_in_fixtures_yml.each do |pupmod|
             STDERR.puts "  ** copy_fixture_modules_to: '#{sut}': '#{pupmod}'" if ENV['BEAKER_helpers_verbose']
             mod_root = File.expand_path( "spec/fixtures/modules/#{pupmod}", File.dirname( fixtures_yml_path ))
-            copy_module_to( sut, {:source => mod_root, :module_name => pupmod} )
+            opts = opts.merge({:source => mod_root,
+                               :module_name => pupmod})
+            copy_module_to( sut, opts )
           end
         end
       end
@@ -91,7 +99,7 @@ module Simp::BeakerHelpers
     STDERR.puts '  ** copy_fixture_modules_to: finished' if ENV['BEAKER_helpers_verbose']
 
     # sync custom facts from the new modules to each SUT's factpath
-    pluginsync_on(suts) if pluginsync
+    pluginsync_on(suts) if opts[:pluginsync]
   end
 
 

--- a/lib/simp/beaker_helpers.rb
+++ b/lib/simp/beaker_helpers.rb
@@ -78,6 +78,8 @@ module Simp::BeakerHelpers
     # choosing a sane default for target_module_path.  In the event that BKR-723 is fixed, then the default
     # specified here should be removed.
 
+    !suts.is_a?( Array ) and suts = Array(suts)
+
     STDERR.puts '  ** copy_fixture_modules_to' if ENV['BEAKER_helpers_verbose']
     ensure_fixture_modules
 

--- a/simp-beaker-helpers.gemspec
+++ b/simp-beaker-helpers.gemspec
@@ -1,6 +1,7 @@
 # -*- encoding: utf-8 -*-
 $LOAD_PATH.unshift File.expand_path('../lib', __FILE__)
 require 'simp/beaker_helpers.rb'
+require 'date'
 
 Gem::Specification.new do |s|
   s.name        = 'simp-beaker-helpers'


### PR DESCRIPTION
See discussion in the [Beaker mailing list](https://groups.google.com/forum/#!topic/puppet-beaker/IxMlNUIRLLA).