### PR TITLE
(SIMP-1281) Add `#write_hieradata_to` method

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ group :system_tests do
   gem 'pry'
   gem 'beaker'
   gem 'beaker-rspec'
+  gem 'vagrant-wrapper'
   # NOTE: Workaround because net-ssh 2.10 is busting beaker
   # lib/ruby/1.9.1/socket.rb:251:in `tcp': wrong number of arguments (5 for 4) (ArgumentError)
   gem 'net-ssh', '~> 2.9.0'

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Methods to assist beaker acceptance tests for SIMP.
       * [`pfact_on`](#pfact_on)
       * [`pluginsync_on`](#pluginsync_on)
     * Hiera
+      * [`write_hieradata_to`](#write_hieradata_to)
       * [`set_hieradata_on`](#set_hieradata_on)
       * [`clear_temp_hieradata`](#clear_temp_hieradata)
 6. [Environment variables](#environment-variables)
@@ -232,18 +233,30 @@ Simulates a `pluginsync` (useful for deploying custom facts) on given SUTs.
 
 `pluginsync_on( suts = hosts )`
 
+#### `write_hieradata_to`
 
-#### `set_hieradata_on`
+Writes a YAML file in the Hiera :datadir of a Beaker::Host.
 
-Set the hiera data file on the provided host to the passed data structure
+**NOTE**: This is useless unless Hiera is configured to use the data file.
+`Beaker::DSL::Helpers::Hiera#write_hiera_config_on` from [beaker-hiera](https://github.com/puppetlabs/beaker-hiera) may be used to configure Hiera.
 
-**NOTE**: This is authoritative; you cannot mix this with other hieradata copies
-
-`set_hieradata_on(host, hieradata, data_file='default')`
+`write_hieradata_to(host, hieradata, terminus = 'default')`
 
  - **`host`**      = _(Array,String,Symbol)_ One or more hosts to act upon
  - **`hieradata`** = _(Hash)_ The full hiera data structure to write to the system
- - **`data_file`** = _(String)_ The filename (not path) of the hiera data
+ - **`terminus`**  = _(String)_ The file basename minus the file extension in which to write the Hiera data
+
+#### `set_hieradata_on`
+
+Writes a YAML file in the Hiera :datdir of a Beaker::Host, then configures the host to use that file exclusively.
+
+**NOTE**: This is authoritative; you cannot mix this with other Hiera data sources.
+
+`set_hieradata_on(host, hieradata, terminus = 'default')`
+
+ - **`host`**      = _(Array,String,Symbol)_ One or more hosts to act upon
+ - **`hieradata`** = _(Hash)_ The full hiera data structure to write to the system
+ - **`terminus`**  = _(String)_ The file basename minus the file extension in which to write the Hiera data
 
 ####  `clear_temp_hieradata`
 

--- a/lib/simp/beaker_helpers.rb
+++ b/lib/simp/beaker_helpers.rb
@@ -421,51 +421,58 @@ done
   end
 
 
-  # Set the hiera data file on the provided host to the passed data structure
+  # Writes a YAML file in the Hiera :datadir of a Beaker::Host.
   #
-  # Note: This is authoritative, you cannot mix this with other hieradata copies
+  # @note This is useless unless Hiera is configured to use the data file.
+  #   @see `Beaker::DSL::Helpers::Hiera#write_hiera_config_on`
   #
-  # @param[sut, Array<Host>, String, Symbol] One or more hosts to act upon.
+  # @param sut  [Array<Host>, String, Symbol] One or more hosts to act upon.
   #
-  # @param[heradata, Hash || String] The full hiera data structure to write to the system.
+  # @param heradata [Hash, String] The full hiera data structure to write to
+  #   the system.
   #
-  # @param[data_file, String] The filename (not path) of the hiera data
-  #                           YAML file to write to the system.
+  # @param terminus [String] The basename of the YAML file minus the extension
+  #   to write to the system.
   #
-  # @param[hiera_config, Array<String>] The hiera config array to write
-  #                                     to the system. Must contain the
-  #                                     Data_file name as one element.
-  def set_hieradata_on(sut, hieradata, data_file='default')
-    # Keep a record of all temporary directories that are created
-    #
-    # Should be cleaned by calling `clear_temp_hiera data` in after(:all)
-    #
-    # Omit this call to be able to delve into the hiera data that is
-    # being created
-    @temp_hieradata_dirs = @temp_hieradata_dirs || []
-
+  # @return [Nil]
+  #
+  # @note This creates a tempdir on the host machine which should be removed
+  #   using `#clear_temp_hieradata` in the `after(:all)` hook.  It may also be
+  #   retained for debugging purposes.
+  #
+  def write_hieradata_to(sut, hieradata, terminus = 'default')
+    @temp_hieradata_dirs ||= []
     data_dir = Dir.mktmpdir('hieradata')
     @temp_hieradata_dirs << data_dir
 
-    fh = File.open(File.join(data_dir,"#{data_file}.yaml"),'w')
-    if hieradata.kind_of? String
-      fh.puts(hieradata)
-    else
-      fh.puts(hieradata.to_yaml)
-    end
-
+    fh = File.open(File.join(data_dir, "#{terminus}.yaml"), 'w')
+    if hieradata.is_a?(String) then fh.puts(hieradata) else fh.puts(hieradata.to_yaml) end
     fh.close
 
-    # If there is already a directory on the system, the SCP below will
-    # add the local directory to the existing directory instead of
-    # replacing the contents.
-    apply_manifest_on(
-      sut,
-      "file { '#{hiera_datadir(sut)}': ensure => 'absent', force => true, recurse => true }"
-    )
+    apply_manifest_on sut, "file { '#{hiera_datadir(sut)}': ensure => 'directory', force => true }"
+    copy_hiera_data_to sut, File.join(data_dir, "#{terminus}.yaml")
+  end
 
-    copy_hiera_data_to(sut, data_dir)
-    write_hiera_config_on(sut, Array(data_file))
+
+  # Write the provided data structure to Hiera's :datadir and configure Hiera to
+  # use that data exclusively.
+  #
+  # @note This is authoritative.  It manages both Hiera data and configuration,
+  #   so it may not be used with other Hiera data sources.
+  #
+  # @param sut  [Array<Host>, String, Symbol] One or more hosts to act upon.
+  #
+  # @param heradata [Hash, String] The full hiera data structure to write to
+  #   the system.
+  #
+  # @param terminus [String] The basename of the YAML file minus the extension
+  #   to write to the system.
+  #
+  # @return [Nil]
+  #
+  def set_hieradata_on(sut, hieradata, terminus = 'default')
+    write_hieradata_to sut, hieradata, terminus
+    write_hiera_config_on sut, Array(terminus)
   end
 
 

--- a/spec/acceptance/set_hieradata_on_spec.rb
+++ b/spec/acceptance/set_hieradata_on_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper_acceptance'
+
+hosts.each do |host|
+  describe '#set_hieradata_on' do
+    context 'when passed a YAML string' do
+      before(:all) { set_hieradata_on(host, "---\n") }
+      after(:all) { on(host, "rm -rf #{host.puppet['hiera_config']} #{hiera_datadir(host)}") }
+
+      it 'creates the datadir' do
+        on host, "test -d #{hiera_datadir(host)}"
+      end
+
+      it 'writes to the configuration file' do
+        stdout = on(host, "cat #{host.puppet['hiera_config']}").stdout
+        expect(stdout).to match(":hierarchy:\n- default")
+      end
+
+      it 'writes the correct contents to the correct file' do
+        stdout = on(host, "cat #{hiera_datadir(host)}/default.yaml").stdout
+        expect(stdout).to eq("---\n")
+      end
+    end
+
+    context 'when passed a hash' do
+      before(:all) { set_hieradata_on(host, { 'foo' => 'bar' }) }
+      after(:all) { on(host, "rm -rf #{host.puppet['hiera_config']} #{hiera_datadir(host)}") }
+
+      it 'creates the datadir' do
+        on host, "test -d #{hiera_datadir(host)}"
+      end
+
+      it 'writes the correct contents to the correct file' do
+        stdout = on(host, "cat #{hiera_datadir(host)}/default.yaml").stdout
+        expect(stdout).to eq("---\nfoo: bar\n")
+      end
+    end
+
+    context 'when the terminus is set' do
+      before(:all) { set_hieradata_on(host, "---\n", 'not-default') }
+      after(:all) { on(host, "rm -rf #{host.puppet['hiera_config']} #{hiera_datadir(host)}") }
+
+      it 'creates the datadir' do
+        on host, "test -d #{hiera_datadir(host)}"
+      end
+
+      it 'writes the correct hierarchy to the configuration file' do
+        stdout = on(host, "cat #{host.puppet['hiera_config']}").stdout
+        expect(stdout).to match(":hierarchy:\n- not-default")
+      end
+
+      it 'writes the correct contents to the correct file' do
+        stdout = on(host, "cat #{hiera_datadir(host)}/not-default.yaml").stdout
+        expect(stdout).to eq("---\n")
+      end
+    end
+  end
+end

--- a/spec/acceptance/write_hieradata_to_spec.rb
+++ b/spec/acceptance/write_hieradata_to_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper_acceptance'
+
+hosts.each do |host|
+  describe '#write_hieradata_to' do
+    context 'when passed a YAML string' do
+      before(:all) { set_hieradata_on(host, "---\n") }
+      after(:all) { on(host, "rm -rf #{hiera_datadir(host)}") }
+
+      it 'creates the datadir' do
+        on host, "test -d #{hiera_datadir(host)}"
+      end
+
+      it 'writes the correct contents to the correct file' do
+        stdout = on(host, "cat #{hiera_datadir(host)}/default.yaml").stdout
+        expect(stdout).to eq("---\n")
+      end
+    end
+
+    context 'when passed a hash' do
+      before(:all) { set_hieradata_on(host, { 'foo' => 'bar' }) }
+      after(:all) { on(host, "rm -rf #{hiera_datadir(host)}") }
+
+      it 'creates the datadir' do
+        on host, "test -d #{hiera_datadir(host)}"
+      end
+
+      it 'writes the correct contents to the correct file' do
+        stdout = on(host, "cat #{hiera_datadir(host)}/default.yaml").stdout
+        expect(stdout).to eq("---\nfoo: bar\n")
+      end
+    end
+
+    context 'when the terminus is set' do
+      before(:all) { set_hieradata_on(host, "---\n", 'not-default') }
+      after(:all) { on(host, "rm -rf #{hiera_datadir(host)}") }
+
+      it 'creates the datadir' do
+        on host, "test -d #{hiera_datadir(host)}"
+      end
+
+      it 'writes the correct contents to the correct file' do
+        stdout = on(host, "cat #{hiera_datadir(host)}/not-default.yaml").stdout
+        expect(stdout).to eq("---\n")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds a method for fine-grained control of Hiera data.  It is
similar to `#set_hieradata_on`, except it may be used to create multiple
Hiera data files on a system, and it does not manage the Hiera
configuration.  The intent is to allow the creation of somewhat more
realistic Hiera setups with multi-level hierarchies and shared common
data.
