### PR TITLE
(SIMP-1281) Make `#set_hieradata_on` non-singleton

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ group :system_tests do
   gem 'pry'
   gem 'beaker'
   gem 'beaker-rspec'
+  gem 'vagrant-wrapper'
   # NOTE: Workaround because net-ssh 2.10 is busting beaker
   # lib/ruby/1.9.1/socket.rb:251:in `tcp': wrong number of arguments (5 for 4) (ArgumentError)
   gem 'net-ssh', '~> 2.9.0'

--- a/README.md
+++ b/README.md
@@ -235,15 +235,17 @@ Simulates a `pluginsync` (useful for deploying custom facts) on given SUTs.
 
 #### `set_hieradata_on`
 
-Set the hiera data file on the provided host to the passed data structure
+Write a YAML file in the Hiera :datadir of a Beaker::Host and optionally sets the :hierarchy.
 
-**NOTE**: This is authoritative; you cannot mix this with other hieradata copies
+**NOTE**: By default this is authoritative and may not be mixed with other Hiera data sources.  This behavior may be disabled by setting the `:manage_config` option to `false`.
 
-`set_hieradata_on(host, hieradata, data_file='default')`
+`set_hieradata_on(host, hieradata, terminus = 'default', opts = {})`
 
  - **`host`**      = _(Array,String,Symbol)_ One or more hosts to act upon
  - **`hieradata`** = _(Hash)_ The full hiera data structure to write to the system
- - **`data_file`** = _(String)_ The filename (not path) of the hiera data
+ - **`terminus`**  = _(String)_ The filename (not path) of the hiera data
+ - **`options`**   = _(Hash)_ Options hash.
+    - **`:manage_config`** = _(Bool)_ Whether or not to manage the `hiera.yaml` configuration file.  Defaults to `true`.
 
 ####  `clear_temp_hieradata`
 

--- a/spec/acceptance/set_hieradata_on_spec.rb
+++ b/spec/acceptance/set_hieradata_on_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper_acceptance'
+
+hosts.each do |host|
+  describe '#set_hieradata_on' do
+    context 'when passed a YAML string' do
+      before(:all) { set_hieradata_on(host, "---\n") }
+      after(:all) { on(host, "rm -rf #{host.puppet['hiera_config']} #{hiera_datadir(host)}") }
+
+      it 'creates the datadir' do
+        on host, "test -d #{hiera_datadir(host)}"
+      end
+
+      it 'writes to the configuration file' do
+        stdout = on(host, "cat #{host.puppet['hiera_config']}").stdout
+        expect(stdout).to match(":hierarchy:\n- default")
+      end
+
+      it 'writes the correct contents to the correct file' do
+        stdout = on(host, "cat #{hiera_datadir(host)}/default.yaml").stdout
+        expect(stdout).to eq("---\n")
+      end
+    end
+
+    context 'when passed a hash' do
+      before(:all) { set_hieradata_on(host, { 'foo' => 'bar' }) }
+      after(:all) { on(host, "rm -rf #{host.puppet['hiera_config']} #{hiera_datadir(host)}") }
+
+      it 'creates the datadir' do
+        on host, "test -d #{hiera_datadir(host)}"
+      end
+
+      it 'writes the correct contents to the correct file' do
+        stdout = on(host, "cat #{hiera_datadir(host)}/default.yaml").stdout
+        expect(stdout).to eq("---\nfoo: bar\n")
+      end
+    end
+
+    context 'when the terminus is set' do
+      before(:all) { set_hieradata_on(host, "---\n", 'not-default') }
+      after(:all) { on(host, "rm -rf #{host.puppet['hiera_config']} #{hiera_datadir(host)}") }
+
+      it 'creates the datadir' do
+        on host, "test -d #{hiera_datadir(host)}"
+      end
+
+      it 'writes the correct hierarchy to the configuration file' do
+        stdout = on(host, "cat #{host.puppet['hiera_config']}").stdout
+        expect(stdout).to match(":hierarchy:\n- not-default")
+      end
+
+      it 'writes the correct contents to the correct file' do
+        stdout = on(host, "cat #{hiera_datadir(host)}/not-default.yaml").stdout
+        expect(stdout).to eq("---\n")
+      end
+    end
+
+    context 'when configuration management is disabled' do
+      before(:all) { set_hieradata_on(host, "---\n", 'default', :manage_config => false) }
+      after(:all) { on(host, "rm -rf #{host.puppet['hiera_config']} #{hiera_datadir(host)}") }
+
+      it 'creates the datadir' do
+        on host, "test -d #{hiera_datadir(host)}"
+      end
+
+      it 'does not touch the hiera config' do
+        on host, "test ! -e #{host.puppet['hiera_config']}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add `manage_config` and `hierarchy` arguments to `#set_hieradata_on` so
it may be used to create a Hiera hierarchy.  Prior to this the function
could only write a single file, would erase all others, and overwrite
the `hiera.yaml` configuration file.  These new options allow the
creation of somewhat more realistic Hiera setups with multi-level
hierarchies and shared common data.
