### PR TITLE
(SIMP-2487) Enable all interfaces on each context

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,6 @@ group :system_tests do
   gem 'pry'
   gem 'beaker'
   gem 'beaker-rspec'
-  gem 'vagrant-wrapper'
   # NOTE: Workaround because net-ssh 2.10 is busting beaker
   # lib/ruby/1.9.1/socket.rb:251:in `tcp': wrong number of arguments (5 for 4) (ArgumentError)
   gem 'net-ssh', '~> 2.9.0'


### PR DESCRIPTION
Various Vagrant VMs may not have their interfaces activated by default.
This patch ensures that all interfaces will be made available.

SIMP-2487 #close