### PR TITLE
(SIMP-2487) Factor out `version.rb`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ cache: bundler
 
 rvm:
   - 2.1.9
-  - 2.0.0
 
 env:
   - SIMP_SKIP_NON_SIMPOS_TESTS=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: ruby
 cache: bundler
 
 rvm:
-  - 1.9.3
+  - 2.1.9
   - 2.0.0
 
 env:

--- a/lib/simp/beaker_helpers.rb
+++ b/lib/simp/beaker_helpers.rb
@@ -1,7 +1,7 @@
 module Simp; end
 
 module Simp::BeakerHelpers
-  VERSION = '1.5.7'
+  require 'simp/beaker_helpers/version'
 
   # use the `puppet fact` face to look up facts on an SUT
   def pfact_on(sut, fact_name)

--- a/lib/simp/beaker_helpers/version.rb
+++ b/lib/simp/beaker_helpers/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 module Simp::BeakerHelpers
-  VERSION = '1.5.7'
+  VERSION = '1.5.8'
 end

--- a/lib/simp/beaker_helpers/version.rb
+++ b/lib/simp/beaker_helpers/version.rb
@@ -1,0 +1,5 @@
+module Simp; end
+
+module Simp::BeakerHelpers
+  VERSION = '1.5.7'
+end

--- a/simp-beaker-helpers.gemspec
+++ b/simp-beaker-helpers.gemspec
@@ -1,6 +1,6 @@
 # -*- encoding: utf-8 -*-
 $LOAD_PATH.unshift File.expand_path('../lib', __FILE__)
-require 'simp/beaker_helpers.rb'
+require 'simp/beaker_helpers/version'
 require 'date'
 
 Gem::Specification.new do |s|


### PR DESCRIPTION
`bundle` commands were failing on fresh checkouts with errors stemming
from the inclusion of `simp/beaker_helpers.rb` in the .gemspec.

This patch fixes the issue, moving the `Simp::BeakerHelpers::VERSION`
constant into its own file and requiring that from the .gemspec instead.

SIMP-2487 #comment Tacking on bugfix to gemspec