### PR TITLE
(SIMP-2998) Bump to Beaker 3.14+

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ group :system_tests do
   gem 'beaker-rspec'
   # NOTE: Workaround because net-ssh 2.10 is busting beaker
   # lib/ruby/1.9.1/socket.rb:251:in `tcp': wrong number of arguments (5 for 4) (ArgumentError)
-  gem 'net-ssh', '~> 2.9.0'
+  gem 'net-ssh'
   gem 'puppetlabs_spec_helper'
   gem 'puppet', puppetversion
 

--- a/Gemfile
+++ b/Gemfile
@@ -17,10 +17,7 @@ group :system_tests do
   gem 'pry'
   gem 'beaker'
   gem 'beaker-rspec'
-  # NOTE: Workaround because net-ssh 2.10 is busting beaker
-  # lib/ruby/1.9.1/socket.rb:251:in `tcp': wrong number of arguments (5 for 4) (ArgumentError)
   gem 'net-ssh'
   gem 'puppetlabs_spec_helper'
   gem 'puppet', puppetversion
-
 end

--- a/lib/simp/beaker_helpers/version.rb
+++ b/lib/simp/beaker_helpers/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 module Simp::BeakerHelpers
-  VERSION = '1.6.0'
+  VERSION = '1.7.0'
 end

--- a/simp-beaker-helpers.gemspec
+++ b/simp-beaker-helpers.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.metadata = {
                  'issue_tracker' => 'https://simp-project.atlassian.net'
                }
-  s.add_runtime_dependency 'beaker', '~> 2'
+  s.add_runtime_dependency 'beaker', '~> 3.14'
   s.add_runtime_dependency 'beaker-puppet_install_helper', '~> 0.6'
 
   ### s.files = Dir['Rakefile', '{bin,lib,spec}/**/*', 'README*', 'LICENSE*'] & `git ls-files -z .`.split("\0")


### PR DESCRIPTION
This version of Beaker works with the version of Ruby shipped with
Puppet and it has the fixes for running on EL and SuSE systems
incorporated

SIMP-2998 #close