### PR TITLE
(SIMP-3154) Add ability to pass fixtures file

### DIFF
--- a/lib/simp/beaker_helpers/version.rb
+++ b/lib/simp/beaker_helpers/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 module Simp::BeakerHelpers
-  VERSION = '1.7.1'
+  VERSION = '1.7.2'
 end


### PR DESCRIPTION
Added the ability to pass static fixtures to simp-core
from other modules. This update is particularly helpful
for testing scenarios; the fixtures list from
pupmod-simp-simp can be passed to simp-core, which alleviates
a maintenance PITA.

SIMP-3154 #comment updated beaker helpers to take fixtures