### PR TITLE
(SIMP-3257) Ignore garbage when getting modulepath

### DIFF
--- a/lib/simp/beaker_helpers/version.rb
+++ b/lib/simp/beaker_helpers/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 module Simp::BeakerHelpers
-  VERSION = '1.7.1'
+  VERSION = '1.7.2'
 end


### PR DESCRIPTION
Facter was throwing garbage into the logs when we were trying to obtain
the modulepath.

Moved fetching the modulepath into its own method and now call that in
the two places where it is used.

SIMP-3257 #close