### PR TITLE
(SIMP-3156) Add SSG and InSpec support to Beaker

### DIFF
--- a/lib/simp/beaker_helpers.rb
+++ b/lib/simp/beaker_helpers.rb
@@ -2,6 +2,9 @@ module Simp; end
 
 module Simp::BeakerHelpers
   require 'simp/beaker_helpers/version'
+  require 'simp/beaker_helpers/inspec'
+  require 'simp/beaker_helpers/ssg'
+
   DEFAULT_PUPPET_AGENT_VERSION = '1.8.3'
 
   # use the `puppet fact` face to look up facts on an SUT
@@ -596,5 +599,4 @@ done
     require 'beaker/puppet_install_helper'
     run_puppet_install_helper(puppet_install_type,  puppet_agent_version)
   end
-
 end

--- a/lib/simp/beaker_helpers/inspec.rb
+++ b/lib/simp/beaker_helpers/inspec.rb
@@ -2,8 +2,6 @@ module Simp::BeakerHelpers
 
   # Helpers for working with Inspec
   class Inspec
-    require 'highline'
-
     # Create a new Inspec helper for the specified host against the specified profile
     #
     # @param sut
@@ -95,6 +93,8 @@ module Simp::BeakerHelpers
     # @return [Hash] A Hash of statistics and a formatted report
     #
     def process_inspec_results
+      require 'highline'
+      
       HighLine.colorize_strings
 
       stats = {

--- a/lib/simp/beaker_helpers/inspec.rb
+++ b/lib/simp/beaker_helpers/inspec.rb
@@ -1,0 +1,169 @@
+module Simp::BeakerHelpers
+
+  # Helpers for working with Inspec
+  class Inspec
+    require 'highline'
+
+    # Create a new Inspec helper for the specified host against the specified profile
+    #
+    # @param sut
+    #   The SUT against which to run
+    #
+    # @param profile
+    #   The name of the profile against which to run
+    #
+    def initialize(sut, profile)
+      @sut = sut
+
+      @sut.install_package('inspec')
+
+      @sut_profile_dir = '/tmp/inspec_tests'
+
+      output_dir = File.absolute_path('sec_results/inspec')
+
+      unless File.directory?(output_dir)
+        FileUtils.mkdir_p(output_dir)
+      end
+
+      inspec_fixtures = File.join(fixtures_path, 'inspec_profiles')
+      os = fact_on(@sut, 'operatingsystem')
+      os_rel = fact_on(@sut, 'operatingsystemmajrelease')
+
+      @inspec_result_file = File.join(output_dir, "#{@sut.hostname}-inspec-#{Time.now.to_i}")
+
+      scp_to(@sut, File.join(inspec_fixtures, "#{os}-#{os_rel}-#{profile}"), @sut_profile_dir)
+
+      # The results of the inspec scan in Hash form
+      @inspec_results = {}
+    end
+
+    # Run the inspec tests and record the results
+    def run
+      sut_inspec_results = '/tmp/inspec_results.json'
+
+      inspec_cmd = "inspec exec --format json #{@sut_profile_dir} > #{sut_inspec_results}"
+      result = on(@sut, inspec_cmd, :accept_all_exit_codes => true)
+
+      tmpdir = Dir.mktmpdir
+      begin
+        Dir.chdir(tmpdir) do
+          scp_from(@sut, sut_inspec_results, '.')
+
+          local_inspec_results = File.basename(sut_inspec_results)
+
+          if File.exist?(local_inspec_results)
+            begin
+              @inspec_results = JSON.load(File.read(local_inspec_results))
+            rescue JSON::ParserError, JSON::GeneratorError
+              @inspec_results = nil
+            end
+          end
+        end
+      ensure
+        FileUtils.remove_entry_secure tmpdir
+      end
+
+      unless @inspec_results
+        File.open(@inspec_result_file + '.err', 'w') do |fh|
+          fh.puts(result.stderr.strip)
+        end
+
+        err_msg = ["Error running inspec command #{inspec_cmd}"]
+        err_msg << "Error captured in #{@inspec_result_file}" + '.err'
+
+        fail(err_msg.join("\n"))
+      end
+    end
+
+    # Output the report
+    #
+    # @param report
+    #   The inspec results Hash
+    #
+    def write_report(report)
+      File.open(@inspec_result_file + '.json', 'w') do |fh|
+        fh.puts(JSON.pretty_generate(@inspec_results))
+      end
+
+      File.open(@inspec_result_file + '.report', 'w') do |fh|
+        fh.puts(report[:report].uncolor)
+      end
+    end
+
+    # Process the results of an InSpec run
+    #
+    # @return [Hash] A Hash of statistics and a formatted report
+    #
+    def process_inspec_results
+      HighLine.colorize_strings
+
+      stats = {
+        :passed  => 0,
+        :failed  => 0,
+        :skipped => 0,
+        :report  => []
+      }
+
+      profiles = @inspec_results['profiles']
+
+      profiles.each do |profile|
+        stats[:report] << "Name: #{profile['name']}"
+
+        profile['controls'].each do |control|
+          title = control['title']
+
+          if title.length > 72
+            title = title[0..71] + '(...)'
+          end
+
+          title_chunks = control['title'].scan(/.{1,72}\W|.{1,72}/).map(&:strip)
+
+          stats[:report] << "\n  Control: #{title_chunks.shift}"
+          unless title_chunks.empty?
+            title_chunks.map!{|x| x = "           #{x}"}
+            stats[:report] << title_chunks.join("\n")
+          end
+
+          if control['results']
+            status = control['results'].first['status']
+          else
+            status = 'skipped'
+          end
+
+          status_str = "    Status: "
+          if status == 'skipped'
+            stats[:skipped] += 1
+
+            stats[:report] << status_str + status.yellow
+            stats[:report] << "    File: #{control['source_location']['ref']}"
+          elsif status =~ /^fail/
+            stats[:failed] += 1
+
+            stats[:report] << status_str + status.red
+            stats[:report] << "    File: #{control['source_location']['ref']}"
+          else
+            stats[:passed] += 1
+
+            stats[:report] << status_str + status.green
+          end
+        end
+
+        stats[:report] << "\n  Statistics:"
+        stats[:report] << "    * Passed: #{stats[:passed].to_s.green}"
+        stats[:report] << "    * Failed: #{stats[:failed].to_s.red}"
+        stats[:report] << "    * Skipped: #{stats[:skipped].to_s.yellow}"
+
+        score = 0
+        if (stats[:passed] + stats[:failed]) > 0
+          score = ((stats[:passed].to_f/(stats[:passed] + stats[:failed])) * 100.0).round(0)
+        end
+
+        stats[:report] << "    * Score:  #{score}%"
+      end
+
+      stats[:report] = stats[:report].join("\n")
+
+      return stats
+    end
+  end
+end

--- a/lib/simp/beaker_helpers/ssg.rb
+++ b/lib/simp/beaker_helpers/ssg.rb
@@ -1,0 +1,133 @@
+module Simp::BeakerHelpers
+  # Helpers for working with the SCAP Security Guide
+  class SSG
+
+    if ENV['BEAKER_ssg_repo']
+      GIT_REPO = ENV['BEAKER_ssg_repo']
+    else
+      GIT_REPO = 'https://github.com/OpenSCAP/scap-security-guide.git'
+    end
+
+    EL_PACKAGES = [
+      'git',
+      'cmake',
+      'openscap-utils',
+      'openscap-python',
+      'python-lxml'
+    ]
+
+    OS_INFO = {
+      'RedHat' => {
+        '6' => {
+          'required_packages' => EL_PACKAGES,
+          'ssg' => {
+            'target'     => 'rhel6',
+            'datastream' => 'ssg-rhel6-ds.xml'
+          }
+        },
+        '7' => {
+          'required_packages' => EL_PACKAGES,
+          'ssg' => {
+            'target'     => 'rhel7',
+            'datastream' => 'ssg-rhel7-ds.xml'
+          }
+        }
+      },
+      'CentOS' => {
+        '6' => {
+          'required_packages' => EL_PACKAGES,
+          'ssg' => {
+            'target'     => 'rhel6',
+            'datastream' => 'ssg-rhel6-ds.xml'
+          }
+        },
+        '7' => {
+          'required_packages' => EL_PACKAGES,
+          'ssg' => {
+            'target'     => 'centos7',
+            'datastream' => 'ssg-centos7-ds.xml'
+          }
+        }
+      }
+    }
+
+    # Create a new SSG helper for the specified host
+    #
+    # @param sut
+    #   The SUT against which to run
+    #
+    def initialize(sut)
+      @sut = sut
+
+      @os = fact_on(@sut, 'operatingsystem')
+      @os_rel = fact_on(@sut, 'operatingsystemmajrelease')
+
+      unless OS_INFO[@os]
+        fail("Error: The '#{@os}' Operating System is not supported")
+      end
+
+      OS_INFO[@os][@os_rel]['required_packages'].each do |pkg|
+        @sut.install_package(pkg)
+      end
+
+      @output_dir = File.absolute_path('sec_results/ssg')
+
+      unless File.directory?(@output_dir)
+        FileUtils.mkdir_p(@output_dir)
+      end
+
+      @result_file = "#{@sut.hostname}-ssg-#{Time.now.to_i}"
+
+      get_ssg_datastream
+    end
+
+    def target
+      OS_INFO[@os][@os_rel]['ssg']['target']
+    end
+
+    def remediate(profile)
+      evaluate(profile, true)
+    end
+
+    def evaluate(profile, remediate=false)
+      cmd = 'cd scap-security-guide && oscap xccdf eval'
+
+      if remediate
+        cmd += ' --remediate'
+      end
+
+      cmd += %( --profile #{profile} --results #{@result_file}.xml --report #{@result_file}.html #{OS_INFO[@os][@os_rel]['ssg']['datastream']})
+
+      # We accept all exit codes here because there have occasionally been
+      # failures in the SSG content and we're not testing that.
+
+      on(@sut, cmd, :accept_all_exit_codes => true)
+
+      ['xml', 'html'].each do |ext|
+        path = "scap-security-guide/#{@result_file}.#{ext}"
+        scp_from(@sut, path, @output_dir)
+
+        fail("Could not retrieve #{path} from #{@sut}") unless File.exist?(File.join(@output_dir, "#{@result_file}.#{ext}"))
+      end
+    end
+
+    private
+
+    def get_ssg_datastream
+      # Allow users to point at a specific SSG release 'tar.bz2' file
+      ssg_release = ENV['BEAKER_ssg_release']
+
+      # Grab the latest SSG release in fixtures if it exists
+      ssg_release ||= Dir.glob('spec/fixtures/ssg_releases/*.bz2').last
+
+      if ssg_release
+        scp_to(@sut, ssg_release)
+
+        on(@sut, %(mkdir -p scap-security-guide && tar -xj -C scap-security-guide --strip-components 1 -f #{ssg_release} && cp scap-security-guide/*ds.xml ~))
+      else
+        on(@sut, %(git clone #{GIT_REPO}))
+        on(@sut, %(cd scap-security-guide/build; cmake ../; make -j4 #{OS_INFO[@os][@os_rel]['ssg']['target']}-content && cp *ds.xml ~))
+      end
+    end
+  end
+end

--- a/lib/simp/rake/beaker.rb
+++ b/lib/simp/rake/beaker.rb
@@ -14,6 +14,7 @@ module Simp::Rake
 
       ::CLEAN.include( %{#{@base_dir}/log} )
       ::CLEAN.include( %{#{@base_dir}/junit} )
+      ::CLEAN.include( %{#{@base_dir}/sec_results} )
 
       yield self if block_given?
 


### PR DESCRIPTION
This adds preliminary support for both SSG scanning and remediation and
InSpec scanning to Beaker for use in testing various systems and
modules.

The README has not been updated because changes may need to be made
once further integration is made.

SIMP-3156 #comment added support in beaker helpers