### PR TITLE
(SIMP-3784) Added 'copy_to' functionality

### DIFF
--- a/lib/simp/beaker_helpers/inspec.rb
+++ b/lib/simp/beaker_helpers/inspec.rb
@@ -42,18 +42,10 @@ module Simp::BeakerHelpers
 
       @result_file = File.join(output_dir, "#{@sut.hostname}-inspec-#{Time.now.to_i}")
 
-      if @sut[:hypervisor] == 'docker'
-        %x(docker cp -L "#{local_profile}" "#{@sut.hostname}:#{@test_dir}")
-      else
-        scp_to(@sut, local_profile, @test_dir)
-      end
+      copy_to(@sut, local_profile, @profile_dir)
 
       if File.exist?(local_deps)
-        if @sut[:hypervisor] == 'docker'
-          %x(docker cp -L "#{local_deps}" "#{@sut.hostname}:#{@deps_root}")
-        else
-          scp_to(@sut, local_deps, @deps_root)
-        end
+        copy_to(@sut, local_deps, @test_dir)
       end
 
       # The results of the inspec scan in Hash form

--- a/lib/simp/beaker_helpers/ssg.rb
+++ b/lib/simp/beaker_helpers/ssg.rb
@@ -132,7 +132,7 @@ module Simp::BeakerHelpers
       ssg_release ||= Dir.glob('spec/fixtures/ssg_releases/*.bz2').last
 
       if ssg_release
-        scp_to(@sut, ssg_release, @scap_working_dir)
+        copy_to(@sut, ssg_release, @scap_working_dir)
 
         on(@sut, %(mkdir -p scap-security-guide && tar -xj -C scap-security-guide --strip-components 1 -f #{ssg_release} && cp scap-security-guide/*ds.xml #{@scap_working_dir}))
       else

--- a/lib/simp/beaker_helpers/version.rb
+++ b/lib/simp/beaker_helpers/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 module Simp::BeakerHelpers
-  VERSION = '1.8.2'
+  VERSION = '1.8.3'
 end


### PR DESCRIPTION
'copy_to' picks the best method for transferring files to the remote
system and performs a copy.

Docker systems can be finicky about rsync connections and using the
native docker commands is MUCH faster so this code will try docker if
appropriate, rsync if available, and fall back to scp.

This does not affect calling the legacy methods.