### PR TITLE
(SIMP-3831) Fix copy_to rsync call

### DIFF
--- a/lib/simp/beaker_helpers.rb
+++ b/lib/simp/beaker_helpers.rb
@@ -33,6 +33,16 @@ module Simp::BeakerHelpers
 
       %x(tar #{exclude_list.join(' ')} -hcf - -C "#{File.dirname(src)}" "#{File.basename(src)}" | docker exec -i "#{sut.hostname}" tar -C "#{dest}" -xf -)
     elsif @has_rsync
+      # This makes rsync_to work like beaker and scp usually do
+      exclude_hack = %(__GARBAge__' -L --exclude '__GARBAge__)
+      opts[:ignore] ||= []
+      opts[:ignore] << exclude_hack
+
+      dest = File.join(dest, File.basename(src)) if File.directory?(src)
+      # End rsync hackery
+
+      sut.mkdir_p(dest)
+
       rsync_to(sut, src, dest, opts)
     else
       scp_to(sut, src, dest, opts)

--- a/lib/simp/beaker_helpers/inspec.rb
+++ b/lib/simp/beaker_helpers/inspec.rb
@@ -72,7 +72,15 @@ module Simp::BeakerHelpers
 
           if File.exist?(local_inspec_results)
             begin
-              @results = JSON.load(File.read(local_inspec_results))
+              # The output is occasionally broken from past experience. Need to
+              # fetch the line that actually looks like JSON
+              inspec_json = File.read(local_inspec_results).lines.find do |line|
+                line.strip!
+
+                line.start_with?('{') && line.end_with?('}')
+              end
+
+              @results = JSON.load(inspec_json) if inspec_json
             rescue JSON::ParserError, JSON::GeneratorError
               @results = nil
             end

--- a/lib/simp/beaker_helpers/version.rb
+++ b/lib/simp/beaker_helpers/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 module Simp::BeakerHelpers
-  VERSION = '1.8.6'
+  VERSION = '1.8.7'
 end

--- a/lib/simp/rake/beaker.rb
+++ b/lib/simp/rake/beaker.rb
@@ -102,7 +102,7 @@ module Simp::Rake
               'default_run' : <true|false> => Default: false
               ```
         EOM
-        task :suites, [:suite, :nodeset] do |t,args|
+        task :suites, [:suite, :nodeset] => ['spec_prep'] do |t,args|
           suite = args[:suite]
           nodeset = args[:nodeset]
 


### PR DESCRIPTION
The upstream version of the rsync call does not behave in the same
manner as either the docker 'tar' behavior or the built-in 'scp'
behavior.

This fixes our call to rsync to work the same way as the other methods
so that all calls to 'copy_to' can expect consistency in behavior.

SIMP-3831 #close