### PR TITLE
(SIMP-3831) Fix bad logic in copy_to

### DIFF
--- a/lib/simp/beaker_helpers.rb
+++ b/lib/simp/beaker_helpers.rb
@@ -34,14 +34,16 @@ module Simp::BeakerHelpers
       %x(tar #{exclude_list.join(' ')} -hcf - -C "#{File.dirname(src)}" "#{File.basename(src)}" | docker exec -i "#{sut.hostname}" tar -C "#{dest}" -xf -)
     elsif @has_rsync
       # This makes rsync_to work like beaker and scp usually do
-      exclude_hack = %(__GARBAge__' -L --exclude '__GARBAge__)
+      exclude_hack = %(__-__' -L --exclude '__-__)
       opts[:ignore] ||= []
       opts[:ignore] << exclude_hack
 
-      dest = File.join(dest, File.basename(src)) if File.directory?(src)
-      # End rsync hackery
+      if File.directory?(src)
+        dest = File.join(dest, File.basename(src)) if File.directory?(src)
+        sut.mkdir_p(dest)
+      end
 
-      sut.mkdir_p(dest)
+      # End rsync hackery
 
       rsync_to(sut, src, dest, opts)
     else

--- a/lib/simp/beaker_helpers/version.rb
+++ b/lib/simp/beaker_helpers/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 module Simp::BeakerHelpers
-  VERSION = '1.8.7'
+  VERSION = '1.8.8'
 end


### PR DESCRIPTION
The rsync target directory workaround did not properly confine itself
to directories.