### PR TITLE
(SIMP-3834) Fix for opts object munging

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Methods to assist beaker acceptance tests for SIMP.
     * [YUM Repo Support](#yum_repo_support)
 5. [Methods](#methods)
     * [`copy_fixture_modules_to`](#copy_fixture_modules_to)
+    * [`copy_to`](#copy_to)
     * [`fix_errata_on`](#fix_errata_on)
     * PKI
       * [`run_fake_pki_ca_on`](#run_fake_pki_ca_on)
@@ -144,6 +145,17 @@ yum_repos:
 ```
 
 ## Methods
+
+#### `copy_to`
+
+Abstracts copying files and directories in the most efficient manner possible.
+
+* If your system is a ``docker`` container it uses ``docker cp``
+* If your system is anything else:
+  * Attempts to use ``rsync`` if it is present on both sides
+  * Falls back to ``scp``
+
+All copy semantics are consistent with what you would expect from ``scp_to``
 
 #### `copy_fixture_modules_to`
 

--- a/lib/simp/beaker_helpers/version.rb
+++ b/lib/simp/beaker_helpers/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 module Simp::BeakerHelpers
-  VERSION = '1.8.8'
+  VERSION = '1.8.9'
 end


### PR DESCRIPTION
* The 'opts' hash appears to be carried globally between all hosts so
  any change to an underlying component will probably cause errors later
  down the line
* Also now check to ensure that rsync is installed on the remote sysetm
  prior to trying to rsync to the system