### PR TITLE
(SIMP-3996) simp-beaker-helpers - Fix BEAKER_fips on CentOS 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+### 1.8.10 / 2017-11-02
+* Fix bug in which dracut was not run on CentOS6, when dracut-fips was
+  installed for a FIPS-enabled test.

--- a/lib/simp/beaker_helpers.rb
+++ b/lib/simp/beaker_helpers.rb
@@ -223,7 +223,8 @@ module Simp::BeakerHelpers
           package { ['dracut-fips'] : ensure => 'latest' }
           ~>
           exec { 'Always run dracut after installing dracut-fips':
-            command => '/usr/bin/dracut -f',
+            path        => ['/usr/bin', '/sbin'],
+            command     => 'dracut -f',
             refreshonly => true
           }
 

--- a/lib/simp/beaker_helpers/version.rb
+++ b/lib/simp/beaker_helpers/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 module Simp::BeakerHelpers
-  VERSION = '1.8.9'
+  VERSION = '1.8.10'
 end


### PR DESCRIPTION
Fix the code that sets the path to dracut.
Also added a changelog.

SIMP-3996 #close