### PR TITLE
(SIMP-4272) Do not use rsync on FIPS clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 1.10.1 / 2018-01-23
+* Ensure that `rsync` is not used once `fips` is enabled on the SUT
+  * If `fips` is enabled on the SUT, but not the running host, rsync
+    connections have a high likelihood of failing
+
 ### 1.10.0 / 2018-01-03
 * Add support for Puppet 5
   * Note: you need to set 'puppet_collection' to 'puppet5' to test Puppet 5 and

--- a/lib/simp/beaker_helpers/version.rb
+++ b/lib/simp/beaker_helpers/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 module Simp::BeakerHelpers
-  VERSION = '1.10.0'
+  VERSION = '1.10.1'
 end


### PR DESCRIPTION
If you are connecting to a FIPS enabled system from a non-FIPS system,
there is a high probability that a rsync connection will fail. Standard
SCP connections are not affected and core Beaker does not provide a
method to pass full options to the sub commands.

SIMP-4272 #comment fips client issue discovered with beaker during testing