### PR TITLE
(SIMP-4512) Improve pluginsync_on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### 1.10.2 / 2018-03-04
+* Reimplemented `pluginsync_on` with a Puppet manifest to completely mimic
+  a native pluginsync
+  - Syncs _all_ assets (e.g., augeas lenses) instead of just the facts
+  - Simpler
+  - Much faster, especially with many modules or SUTs
+
 ### 1.10.1 / 2018-02-13
 * Updated the Puppet version mapping list for Puppet 5
 * Fixed a bug in the way that the latest Puppet 5 version was being determined

--- a/lib/simp/beaker_helpers/version.rb
+++ b/lib/simp/beaker_helpers/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 module Simp::BeakerHelpers
-  VERSION = '1.10.1'
+  VERSION = '1.10.2'
 end


### PR DESCRIPTION
Before this commit, `pluginsync_on` only synced facts and used many
expensive `on()` methods that scaled poorly with both modules and hosts.

This patch re-implements the method with a simple puppet manifest.  It
syncs all the assets a normal pluginsync would (including augeas lenses) and
only executes a single `apply_manifest_on` per host.

SIMP-4512 #close