### PR TITLE
Avoid warnings when using puppet config print

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.10.3 / 2018-03-23
+* Avoid warnings when using `puppet config print`
+
 ### 1.10.2 / 2018-03-04
 * Reimplemented `pluginsync_on` with a Puppet manifest to completely mimic
   a native pluginsync

--- a/lib/simp/beaker_helpers.rb
+++ b/lib/simp/beaker_helpers.rb
@@ -74,7 +74,7 @@ module Simp::BeakerHelpers
   # Returns the modulepath on the SUT, as an Array
   def puppet_modulepath_on(sut, environment='production')
     on(
-      sut, "puppet config print modulepath --environment #{environment}"
+      sut, "puppet config print --section main modulepath --environment #{environment} 2>/dev/null"
     ).output.lines.last.strip.split(':')
   end
 

--- a/lib/simp/beaker_helpers/version.rb
+++ b/lib/simp/beaker_helpers/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 module Simp::BeakerHelpers
-  VERSION = '1.10.2'
+  VERSION = '1.10.3'
 end


### PR DESCRIPTION
Since https://tickets.puppetlabs.com/browse/PUP-2868, we receive a
warning if we don't specify the section. This is a problem for puppet
5.5.
These warnings were parsed by ruby and provide incorrect return.

We need to ignore stderr as we still have a problem with
https://tickets.puppetlabs.com/browse/PUP-8566