### PR TITLE
(SIMP-4416) Work around removal of Dir::Tmpname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.10.6 / 2018-05-07
+* Added Simp::BeakerHelpers.tmpname method to work around the removal of
+  Dir::Tmpname in Ruby 2.5
+
 ### 1.10.5 / 2018-04-27
 * Fix issue with direct copy to/from docker containers
 * Add necessary package for SSG builds

--- a/lib/simp/beaker_helpers.rb
+++ b/lib/simp/beaker_helpers.rb
@@ -5,6 +5,12 @@ module Simp::BeakerHelpers
   require 'simp/beaker_helpers/inspec'
   require 'simp/beaker_helpers/ssg'
 
+  # Stealing this from the Ruby 2.5 Dir::Tmpname workaround from Rails
+  def self.tmpname
+    t = Time.new.strftime("%Y%m%d")
+    "simp-beaker-helpers-#{t}-#{$$}-#{rand(0x100000000).to_s(36)}.tmp"
+  end
+
   # This is the *oldest* version that the latest release of SIMP supports
   #
   # This is done so that we know if some new thing that we're using breaks the
@@ -175,7 +181,7 @@ module Simp::BeakerHelpers
 
           Dir.chdir(mod_root) do
             begin
-              tarfile = Dir::Tmpname.make_tmpname(['beaker','.tar'],nil)
+              tarfile = "#{Simp::BeakerHelpers.tmpname}.tar"
 
               excludes = PUPPET_MODULE_INSTALL_IGNORE.map do |x|
                 x = "--exclude '*/#{x}'"

--- a/lib/simp/beaker_helpers/version.rb
+++ b/lib/simp/beaker_helpers/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 module Simp::BeakerHelpers
-  VERSION = '1.10.5'
+  VERSION = '1.10.6'
 end


### PR DESCRIPTION
SIMP-4416 #comment discovered that Dir::Tmpname is removed in Ruby 2.5