### PR TITLE
(SIMP-4679) Fix dependency on highline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,8 @@
-### 1.10.9 / 2018-06-01
-* Add runtime dependency on `highline` for the `inspec` reporting
-
 ### 1.10.8 / 2018-05-18
 * New env var BEAKER_no_fix_interfaces, set to skip the fix that brings up all
   vagrant interfaces
 * Parallelized pre-test setup actions that are used across all hosts using `block_on`
+* Add runtime dependency on `highline` for the `inspec` reporting
 
 ### 1.10.7 / 2018-05-11
 * Updated README

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.10.9 / 2018-06-01
+* Add runtime dependency on `highline` for the `inspec` reporting
+
 ### 1.10.8 / 2018-05-18
 * New env var BEAKER_no_fix_interfaces, set to skip the fix that brings up all
   vagrant interfaces

--- a/lib/simp/beaker_helpers/version.rb
+++ b/lib/simp/beaker_helpers/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 module Simp::BeakerHelpers
-  VERSION = '1.10.9'
+  VERSION = '1.10.8'
 end

--- a/lib/simp/beaker_helpers/version.rb
+++ b/lib/simp/beaker_helpers/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 module Simp::BeakerHelpers
-  VERSION = '1.10.8'
+  VERSION = '1.10.9'
 end

--- a/simp-beaker-helpers.gemspec
+++ b/simp-beaker-helpers.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'beaker', '~> 3.14'
   s.add_runtime_dependency 'beaker-puppet', '~> 0.8.0'
   s.add_runtime_dependency 'beaker-puppet_install_helper', '~> 0.6'
+  s.add_runtime_dependency 'highline', '~> 1.6'
 
   ### s.files = Dir['Rakefile', '{bin,lib,spec}/**/*', 'README*', 'LICENSE*'] & `git ls-files -z .`.split("\0")
   s.files       = `git ls-files`.split("\n")


### PR DESCRIPTION
Our inspec reporting needs highline but the gem did not require it as a
runtime dependency