### PR TITLE
(SIMP-MAINT) Use the latest SSG tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-### 1.10.9 /2018-06-14
+
+### 1.10.9 /2018-06-22
+* Ensure that the SSG is built from the latest tag instead of master
+* Provide the option to pass a specific branch to the SSG builds
 * Pin the suite base directory off of the global base directory instead of
   local to wherever the system happenes to be at the time.
 

--- a/lib/simp/beaker_helpers/ssg.rb
+++ b/lib/simp/beaker_helpers/ssg.rb
@@ -8,6 +8,13 @@ module Simp::BeakerHelpers
       GIT_REPO = 'https://github.com/OpenSCAP/scap-security-guide.git'
     end
 
+    # If this is not set, the closest tag to the default branch will be used
+    GIT_BRANCH = nil
+
+    if ENV['BEAKER_ssg_branch']
+      GIT_BRANCH = ENV['BEAKER_ssg_branch']
+    end
+
     EL_PACKAGES = [
       'PyYAML',
       'cmake',
@@ -139,6 +146,11 @@ module Simp::BeakerHelpers
         on(@sut, %(mkdir -p scap-security-guide && tar -xj -C scap-security-guide --strip-components 1 -f #{ssg_release} && cp scap-security-guide/*ds.xml #{@scap_working_dir}))
       else
         on(@sut, %(git clone #{GIT_REPO}))
+        if GIT_BRANCH
+          on(@sut, %(cd scap-security-guide; git checkout #{GIT_BRANCH}))
+        else
+          on(@sut, %(cd scap-security-guide; git checkout $(git describe --abbrev=0 --tags)))
+        end
         on(@sut, %(cd scap-security-guide/build; cmake ../; make -j4 #{OS_INFO[@os][@os_rel]['ssg']['build_target']}-content && cp *ds.xml #{@scap_working_dir}))
       end
     end

--- a/simp-beaker-helpers.gemspec
+++ b/simp-beaker-helpers.gemspec
@@ -23,6 +23,11 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'beaker-puppet_install_helper', '~> 0.6'
   s.add_runtime_dependency 'highline', '~> 1.6'
 
+  # Because fog-opensack dropped support for Ruby < 2.2.0
+  if RUBY_VERSION <= '2.2.0'
+    s.add_runtime_dependency 'fog-openstack', '0.1.25'
+  end
+
   ### s.files = Dir['Rakefile', '{bin,lib,spec}/**/*', 'README*', 'LICENSE*'] & `git ls-files -z .`.split("\0")
   s.files       = `git ls-files`.split("\n")
   s.test_files  = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
The 'master' branch started failing to build so the SSG code was updated
to use the latest tag instead by default