### PR TITLE
(SIMP-MAINT) Use the latest SSG tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
+### 1.10.10/ 2018-06-22
+* Version bump due to being released without a git tag
 
-### 1.10.9 /2018-06-22
+### 1.10.9 / 2018-06-22
 * Ensure that the SSG is built from the latest tag instead of master
 * Provide the option to pass a specific branch to the SSG builds
 * Pin the suite base directory off of the global base directory instead of

--- a/lib/simp/beaker_helpers/version.rb
+++ b/lib/simp/beaker_helpers/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 module Simp::BeakerHelpers
-  VERSION = '1.10.9'
+  VERSION = '1.10.10'
 end


### PR DESCRIPTION
The 'master' branch started failing to build so the SSG code was updated
to use the latest tag instead by default