### PR TITLE
(SIMP-4989) Remove parallelization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.10.12 / 2018-07-09
+* Forced all parallelization to `false` by default due to random issues with
+  Beaker
+
 ### 1.10.11 / 2018-06-25
 * Pinned `fog-openstack` to `0.1.25` for all releases due to dropping support
   for Ruby 1.9 in `0.1.26`. This should be removed once we drop support for

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Methods to assist beaker acceptance tests for SIMP.
     * [`install_puppet`](#install_puppet)
 * [Environment variables](#environment-variables-1)
     * [`BEAKER_fips`](#beaker_fips)
+    * [`BEAKER_SIMP_parallel`](#beaker_simp_parallel)
     * [`BEAKER_spec_prep`](#beaker_spec_prep)
     * [`BEAKER_stringify_facts`](#beaker_stringify_facts)
     * [`BEAKER_use_fixtures_dir_for_modules`](#beaker_use_fixtures_dir_for_modules)
@@ -339,6 +340,14 @@ spec_prep` to populate the missing modules using `.fixtures.yml`.  Note that
 this will _not_ update modules that are already present under
 `spec/fixtures/modules`.
 
+#### `BEAKER_SIMP_parallel`
+
+_(Default: `no`)_  Execute each SIMP host setup method such as
+`Simp::BeakerHelpers::copy_fixure_modules_to` and `Simp::BeakerHelpers::fix_errata_on`
+on all hosts in a node set in parallel. Uses parallelization provided by Beaker.
+
+**NOTE:** Beaker's parallelization capability does not always work, so a word
+to the wise is sufficient.
 
 #### `BEAKER_stringify_facts`
 #### `BEAKER_use_fixtures_dir_for_modules`

--- a/lib/simp/beaker_helpers.rb
+++ b/lib/simp/beaker_helpers.rb
@@ -165,7 +165,7 @@ module Simp::BeakerHelpers
     opts[:pluginsync] = opts.fetch(:pluginsync, true)
 
     unless ENV['BEAKER_copy_fixtures'] == 'no'
-      block_on(suts, :run_in_parallel => true) do |sut|
+      block_on(suts, :run_in_parallel => false) do |sut|
         STDERR.puts "  ** copy_fixture_modules_to: '#{sut}'" if ENV['BEAKER_helpers_verbose']
 
         # Use spec_prep to provide modules (this supports isolated networks)
@@ -214,7 +214,7 @@ module Simp::BeakerHelpers
   def enable_fips_mode_on( suts = hosts )
     puts '== configuring FIPS mode on SUTs'
     puts '  -- (use BEAKER_fips=no to disable)'
-    block_on(suts, :run_in_parallel => true) do |sut|
+    block_on(suts, :run_in_parallel => false) do |sut|
       puts "  -- enabling FIPS on '#{sut}'"
 
       # We need to use FIPS compliant algorithms and keylengths as per the FIPS
@@ -327,7 +327,7 @@ DEFAULT_KERNEL_TITLE=`/sbin/grubby --info=\\\${DEFAULT_KERNEL_INFO} | grep -m1 t
       :timeout
     ]
 
-    block_on(suts, :run_in_parallel => true) do |sut|
+    block_on(suts, :run_in_parallel => false) do |sut|
       if sut['yum_repos']
         sut['yum_repos'].each_pair do |repo, metadata|
           repo_manifest = %(yumrepo { #{repo}:)
@@ -363,7 +363,7 @@ DEFAULT_KERNEL_TITLE=`/sbin/grubby --info=\\\${DEFAULT_KERNEL_INFO} | grep -m1 t
   # Apply known OS fixes we need to run Beaker on each SUT
   def fix_errata_on( suts = hosts )
 
-    block_on(suts, :run_in_parallel => true) do |sut|
+    block_on(suts, :run_in_parallel => false) do |sut|
       # We need to be able to flip between server and client without issue
       on sut, 'puppet resource group puppet gid=52'
       on sut, 'puppet resource user puppet comment="Puppet" gid="52" uid="52" home="/var/lib/puppet" managehome=true'
@@ -556,7 +556,7 @@ done
   #
   # Can be passed any number of hosts either singly or as an Array
   def activate_interfaces(hosts)
-    block_on(hosts, :run_in_parallel => true) do |host|
+    block_on(hosts, :run_in_parallel => false) do |host|
       interfaces_fact = retry_on(host,'facter interfaces', verbose: true).stdout
 
       interfaces = interfaces_fact.strip.split(',')
@@ -682,7 +682,7 @@ done
           noop    => false
         }
     PLUGINSYNC_MANIFEST
-    apply_manifest_on(hosts, pluginsync_manifest, :run_in_parallel => true)
+    apply_manifest_on(hosts, pluginsync_manifest, :run_in_parallel => false)
   end
 
 

--- a/lib/simp/beaker_helpers.rb
+++ b/lib/simp/beaker_helpers.rb
@@ -165,7 +165,8 @@ module Simp::BeakerHelpers
     opts[:pluginsync] = opts.fetch(:pluginsync, true)
 
     unless ENV['BEAKER_copy_fixtures'] == 'no'
-      block_on(suts, :run_in_parallel => false) do |sut|
+      parallel = (ENV['BEAKER_SIMP_parallel'] == 'yes')
+      block_on(suts, :run_in_parallel => parallel) do |sut|
         STDERR.puts "  ** copy_fixture_modules_to: '#{sut}'" if ENV['BEAKER_helpers_verbose']
 
         # Use spec_prep to provide modules (this supports isolated networks)
@@ -214,7 +215,8 @@ module Simp::BeakerHelpers
   def enable_fips_mode_on( suts = hosts )
     puts '== configuring FIPS mode on SUTs'
     puts '  -- (use BEAKER_fips=no to disable)'
-    block_on(suts, :run_in_parallel => false) do |sut|
+    parallel = (ENV['BEAKER_SIMP_parallel'] == 'yes')
+    block_on(suts, :run_in_parallel => parallel) do |sut|
       puts "  -- enabling FIPS on '#{sut}'"
 
       # We need to use FIPS compliant algorithms and keylengths as per the FIPS
@@ -327,7 +329,8 @@ DEFAULT_KERNEL_TITLE=`/sbin/grubby --info=\\\${DEFAULT_KERNEL_INFO} | grep -m1 t
       :timeout
     ]
 
-    block_on(suts, :run_in_parallel => false) do |sut|
+    parallel = (ENV['BEAKER_SIMP_parallel'] == 'yes')
+    block_on(suts, :run_in_parallel => parallel) do |sut|
       if sut['yum_repos']
         sut['yum_repos'].each_pair do |repo, metadata|
           repo_manifest = %(yumrepo { #{repo}:)
@@ -362,8 +365,8 @@ DEFAULT_KERNEL_TITLE=`/sbin/grubby --info=\\\${DEFAULT_KERNEL_INFO} | grep -m1 t
 
   # Apply known OS fixes we need to run Beaker on each SUT
   def fix_errata_on( suts = hosts )
-
-    block_on(suts, :run_in_parallel => false) do |sut|
+    parallel = (ENV['BEAKER_SIMP_parallel'] == 'yes')
+    block_on(suts, :run_in_parallel => parallel) do |sut|
       # We need to be able to flip between server and client without issue
       on sut, 'puppet resource group puppet gid=52'
       on sut, 'puppet resource user puppet comment="Puppet" gid="52" uid="52" home="/var/lib/puppet" managehome=true'
@@ -556,7 +559,8 @@ done
   #
   # Can be passed any number of hosts either singly or as an Array
   def activate_interfaces(hosts)
-    block_on(hosts, :run_in_parallel => false) do |host|
+    parallel = (ENV['BEAKER_SIMP_parallel'] == 'yes')
+    block_on(hosts, :run_in_parallel => parallel) do |host|
       interfaces_fact = retry_on(host,'facter interfaces', verbose: true).stdout
 
       interfaces = interfaces_fact.strip.split(',')
@@ -682,7 +686,8 @@ done
           noop    => false
         }
     PLUGINSYNC_MANIFEST
-    apply_manifest_on(hosts, pluginsync_manifest, :run_in_parallel => false)
+    parallel = (ENV['BEAKER_SIMP_parallel'] == 'yes')
+    apply_manifest_on(hosts, pluginsync_manifest, :run_in_parallel => parallel)
   end
 
 

--- a/lib/simp/beaker_helpers/version.rb
+++ b/lib/simp/beaker_helpers/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 module Simp::BeakerHelpers
-  VERSION = '1.10.11'
+  VERSION = '1.10.12'
 end


### PR DESCRIPTION
Issues with Beaker are causing all parallel activities to fail so they
are being forcibly disabled until we can figure out what's going on.

SIMP-4989 #comment disable parallelization