### PR TITLE
(SIMP-5043) Update table with puppet-agent 1.10.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.10.13 / 2018-07-24
+* Update puppet to puppet-agent mapping table for puppet-agent 1.10.14
+
 ### 1.10.12 / 2018-07-09
 * Forced all parallelization to `false` by default due to random issues with
   Beaker

--- a/files/puppet-agent-versions.yaml
+++ b/files/puppet-agent-versions.yaml
@@ -4,6 +4,7 @@
 #   - https://docs.puppet.com/puppet/latest/about_agent.html
 #
 version_mappings:
+  '4.10.12': '1.10.14'
   '4.10.11': '1.10.12'
   '4.10.10': '1.10.10'
   '4.10.9': '1.10.9'

--- a/lib/simp/beaker_helpers/version.rb
+++ b/lib/simp/beaker_helpers/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 module Simp::BeakerHelpers
-  VERSION = '1.10.12'
+  VERSION = '1.10.13'
 end


### PR DESCRIPTION
Update puppet-to-puppet-agent table to include version of puppet-agent
currently slated for SIMP-6.2.0

SIMP-5043 #comment simp-beaker-helpers update