### PR TITLE
(SIMP-5158) Added a local temp webserver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 1.11.0 /2018-08-03
+* Added a Simp::BeakerHelpers::WebServe module to allow for a local web server
+  to be spawned against a local directory for simple testing requiring external
+  web artifacts.
+
 ### 1.10.14 / 2018-08-01
 * Pinned `net-telnet` to `~> 0.1.1` for all releases due to dropping support
   for Ruby less than 2.3 in `0.2.X`. This should be removed once we drop

--- a/README.md
+++ b/README.md
@@ -34,11 +34,14 @@ Methods to assist beaker acceptance tests for SIMP.
     * [`latest_puppet_agent_version_for(puppet_version)`](#latest_puppet_agent_version_forpuppet_version)
     * [`install_puppet`](#install_puppet)
 * [Environment variables](#environment-variables-1)
+    * [`BEAKER_SIMP_webserve`](#beaker_simp_webserve)
+    * [`BEAKER_SIMP_webserve_port`](#beaker_simp_webserve_port)
     * [`BEAKER_fips`](#beaker_fips)
-    * [`BEAKER_SIMP_parallel`](#beaker_simp_parallel)
     * [`BEAKER_spec_prep`](#beaker_spec_prep)
+    * [`BEAKER_SIMP_parallel`](#beaker_simp_parallel)
     * [`BEAKER_stringify_facts`](#beaker_stringify_facts)
     * [`BEAKER_use_fixtures_dir_for_modules`](#beaker_use_fixtures_dir_for_modules)
+    * [`BEAKER_no_fix_interfaces`](#beaker_no_fix_interfaces)
     * [PUPPET_VERSION](#puppet_version)
 * [Examples](#examples)
   * [Prep OS, Generate and copy PKI certs to each SUT](#prep-os-generate-and-copy-pki-certs-to-each-sut)
@@ -325,6 +328,18 @@ variables, it will default the version to the value of
 Simp::BeakerHelpers::DEFAULT_PUPPET_AGENT_VERSION, which is currently '1.10.4'.
 
 ## Environment variables
+
+#### `BEAKER_SIMP_webserve`
+
+If set, will start up a local web server that serves the directory specified in
+this environment variable as the web server root directory on the port
+specified by `BEAKER_SIMP_webserve_port`.
+
+The web server will be destroyed on application exit.
+
+#### `BEAKER_SIMP_webserve_port`
+
+_(Default: 11111)_ The port to use for the temporary local web server.
 
 #### `BEAKER_fips`
 

--- a/lib/simp/beaker_helpers.rb
+++ b/lib/simp/beaker_helpers.rb
@@ -4,6 +4,9 @@ module Simp::BeakerHelpers
   require 'simp/beaker_helpers/version'
   require 'simp/beaker_helpers/inspec'
   require 'simp/beaker_helpers/ssg'
+  require 'simp/beaker_helpers/webserve'
+
+  include Simp::BeakerHelpers::WebServe::Run
 
   # Stealing this from the Ruby 2.5 Dir::Tmpname workaround from Rails
   def self.tmpname

--- a/lib/simp/beaker_helpers/version.rb
+++ b/lib/simp/beaker_helpers/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 module Simp::BeakerHelpers
-  VERSION = '1.10.14'
+  VERSION = '1.11.0'
 end

--- a/lib/simp/beaker_helpers/webserve.rb
+++ b/lib/simp/beaker_helpers/webserve.rb
@@ -1,0 +1,61 @@
+module Simp::BeakerHelpers
+
+  # This is primarily designed for testing YUM installation but can be used for
+  # serving up any directory on the local system.
+  #
+  # The environment variables should be used in your nodesets to auto-hook the
+  # yum repositories if being used for that purpose.
+  class WebServe
+
+    attr_reader :dir
+    attr_reader :port
+
+    # Start a new webrick instance on the designated port
+    def initialize(dir, port=11111)
+      @dir = dir
+      @port = port
+
+      if @dir
+        @dir = File.expand_path(@dir)
+
+        fail("Could not find directory to serve via webrick: '#{@dir}'") unless File.directory?(@dir)
+
+        pid = fork do
+          require 'webrick'
+
+          server = WEBrick::HTTPServer.new(:Port => @port, :DocumentRoot => @dir)
+
+          trap 'INT' do server.shutdown end
+          trap 'HUP' do server.shutdown end
+          trap 'TERM' do server.shutdown end
+
+          server.start
+        end
+
+        at_exit do
+          Process.kill("INT", pid)
+        end
+      end
+    end
+  end
+
+  # Process the following environment variables and serve a directory via webrick
+  # on the designated port.
+  #
+  # BEAKER_SIMP_webserve=<path to serve via webrick>
+  # BEAKER_SIMP_webserve_port=<port to use (defaults to 11111)>
+  #
+  # When included, this code will read the environment variables and spin up a
+  # Webrick web server accordingly basically a 'quick and dirty' shim around
+  # having to repeat the code everywhere.
+  module WebServe::Run
+    dir = ENV['BEAKER_SIMP_webserve']
+    port = ENV['BEAKER_SIMP_webserve_port']
+
+    if port
+      Simp::BeakerHelpers::WebServe.new(dir, port)
+    else
+      Simp::BeakerHelpers::WebServe.new(dir)
+    end
+  end
+end


### PR DESCRIPTION
This adds a Simp::BeakerHelpers::WebServe module that easily allows
users to spin up a temporary webserver.

My personal need was to be able to host local YUM repositories but it
can host anything on the local filesystem that the running user has
access to.

SIMP-5158 #close