### PR TITLE
(SIMP-MAINT) Deprecation Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
-### 1.11.0 / 2018-09-09
+### 1.11.1 / 2018-10-03
+* Deprecate the 'terminus' parameter in 'write_hieradata_to' and 'set_hieradata_on'
+* Add 'copy_hiera_data_to' method to replace the one from beaker-hiera
+* Add 'hiera_datadir' method to replace the one from beaker-hiera
+* Change InSpec to use the 'reporter' option instead of 'format'
+* Update the SSG to point to the new ComplianceAsCode repository
+
+### 1.11.0 / 2018-10-01
 * Add support for Beaker 4
 
 ### 1.10.14 / 2018-08-01

--- a/lib/simp/beaker_helpers.rb
+++ b/lib/simp/beaker_helpers.rb
@@ -609,7 +609,7 @@ done
   #
   # @param sut  [Array<Host>, String, Symbol] One or more hosts to act upon.
   #
-  # @param heradata [Hash, String] The full hiera data structure to write to
+  # @param hieradata [Hash, String] The full hiera data structure to write to
   #   the system.
   #
   # @param terminus [String]  DEPRECATED - This will be removed in a future

--- a/lib/simp/beaker_helpers.rb
+++ b/lib/simp/beaker_helpers.rb
@@ -675,6 +675,9 @@ done
     # Snag the actual path without the extra bits
     puppet_lookup_info = puppet_lookup_info.first.strip.split('"').last
 
+    # Make the parent directories exist
+    sut.mkdir_p(File.dirname(puppet_lookup_info))
+
     # We just want the data directory name
     datadir_name = puppet_lookup_info.split(puppet_env_path).last
 
@@ -686,9 +689,6 @@ done
 
     # Constitute the full path to the data directory
     datadir_path = puppet_env_path + file_sep + datadir_name
-
-    # Make the directory if it does not exist (it usually does not)
-    sut.mkdir_p(datadir_path)
 
     # Return the path to the data directory
     return datadir_path

--- a/lib/simp/beaker_helpers/inspec.rb
+++ b/lib/simp/beaker_helpers/inspec.rb
@@ -56,7 +56,7 @@ module Simp::BeakerHelpers
     def run
       sut_inspec_results = '/tmp/inspec_results.json'
 
-      inspec_cmd = "inspec exec --format json #{@test_dir} > #{sut_inspec_results}"
+      inspec_cmd = "inspec exec '#{@test_dir}' --reporter json > #{sut_inspec_results}"
       result = on(@sut, inspec_cmd, :accept_all_exit_codes => true)
 
       tmpdir = Dir.mktmpdir

--- a/lib/simp/beaker_helpers/ssg.rb
+++ b/lib/simp/beaker_helpers/ssg.rb
@@ -5,7 +5,7 @@ module Simp::BeakerHelpers
     if ENV['BEAKER_ssg_repo']
       GIT_REPO = ENV['BEAKER_ssg_repo']
     else
-      GIT_REPO = 'https://github.com/OpenSCAP/scap-security-guide.git'
+      GIT_REPO = 'https://github.com/ComplianceAsCode/content.git'
     end
 
     # If this is not set, the closest tag to the default branch will be used
@@ -143,15 +143,15 @@ module Simp::BeakerHelpers
       if ssg_release
         copy_to(@sut, ssg_release, @scap_working_dir)
 
-        on(@sut, %(mkdir -p scap-security-guide && tar -xj -C scap-security-guide --strip-components 1 -f #{ssg_release} && cp scap-security-guide/*ds.xml #{@scap_working_dir}))
+        on(@sut, %(mkdir -p scap-content && tar -xj -C scap-content --strip-components 1 -f #{ssg_release} && cp scap-content/*ds.xml #{@scap_working_dir}))
       else
-        on(@sut, %(git clone #{GIT_REPO}))
+        on(@sut, %(git clone #{GIT_REPO} scap-content))
         if GIT_BRANCH
-          on(@sut, %(cd scap-security-guide; git checkout #{GIT_BRANCH}))
+          on(@sut, %(cd scap-content; git checkout #{GIT_BRANCH}))
         else
-          on(@sut, %(cd scap-security-guide; git checkout $(git describe --abbrev=0 --tags)))
+          on(@sut, %(cd scap-content; git checkout $(git describe --abbrev=0 --tags)))
         end
-        on(@sut, %(cd scap-security-guide/build; cmake ../; make -j4 #{OS_INFO[@os][@os_rel]['ssg']['build_target']}-content && cp *ds.xml #{@scap_working_dir}))
+        on(@sut, %(cd scap-content/build; cmake ../; make -j4 #{OS_INFO[@os][@os_rel]['ssg']['build_target']}-content && cp *ds.xml #{@scap_working_dir}))
       end
     end
   end

--- a/lib/simp/beaker_helpers/version.rb
+++ b/lib/simp/beaker_helpers/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 module Simp::BeakerHelpers
-  VERSION = '1.11.0'
+  VERSION = '1.11.1'
 end

--- a/spec/acceptance/suites/default/set_hieradata_on_spec.rb
+++ b/spec/acceptance/suites/default/set_hieradata_on_spec.rb
@@ -4,53 +4,29 @@ hosts.each do |host|
   describe '#set_hieradata_on' do
     context 'when passed a YAML string' do
       before(:all) { set_hieradata_on(host, "---\n") }
-      after(:all) { on(host, "rm -rf #{host.puppet['hiera_config']} #{hiera_datadir(host)}") }
+      after(:all) { on(host, "rm -rf #{hiera_datadir(host)}") }
 
       it 'creates the datadir' do
         on host, "test -d #{hiera_datadir(host)}"
       end
 
-      it 'writes to the configuration file' do
-        stdout = on(host, "cat #{host.puppet['hiera_config']}").stdout
-        expect(stdout).to match(":hierarchy:\n- default")
-      end
-
       it 'writes the correct contents to the correct file' do
-        stdout = on(host, "cat #{hiera_datadir(host)}/default.yaml").stdout
+        stdout = on(host, "cat #{hiera_datadir(host)}/common.yaml").stdout
         expect(stdout).to eq("---\n")
       end
     end
 
     context 'when passed a hash' do
       before(:all) { set_hieradata_on(host, { 'foo' => 'bar' }) }
-      after(:all) { on(host, "rm -rf #{host.puppet['hiera_config']} #{hiera_datadir(host)}") }
+      after(:all) { on(host, "rm -rf #{hiera_datadir(host)}") }
 
       it 'creates the datadir' do
         on host, "test -d #{hiera_datadir(host)}"
       end
 
       it 'writes the correct contents to the correct file' do
-        stdout = on(host, "cat #{hiera_datadir(host)}/default.yaml").stdout
+        stdout = on(host, "cat #{hiera_datadir(host)}/common.yaml").stdout
         expect(stdout).to eq("---\nfoo: bar\n")
-      end
-    end
-
-    context 'when the terminus is set' do
-      before(:all) { set_hieradata_on(host, "---\n", 'not-default') }
-      after(:all) { on(host, "rm -rf #{host.puppet['hiera_config']} #{hiera_datadir(host)}") }
-
-      it 'creates the datadir' do
-        on host, "test -d #{hiera_datadir(host)}"
-      end
-
-      it 'writes the correct hierarchy to the configuration file' do
-        stdout = on(host, "cat #{host.puppet['hiera_config']}").stdout
-        expect(stdout).to match(":hierarchy:\n- not-default")
-      end
-
-      it 'writes the correct contents to the correct file' do
-        stdout = on(host, "cat #{hiera_datadir(host)}/not-default.yaml").stdout
-        expect(stdout).to eq("---\n")
       end
     end
   end

--- a/spec/acceptance/suites/default/write_hieradata_to_spec.rb
+++ b/spec/acceptance/suites/default/write_hieradata_to_spec.rb
@@ -11,7 +11,7 @@ hosts.each do |host|
       end
 
       it 'writes the correct contents to the correct file' do
-        stdout = on(host, "cat #{hiera_datadir(host)}/default.yaml").stdout
+        stdout = on(host, "cat #{hiera_datadir(host)}/common.yaml").stdout
         expect(stdout).to eq("---\n")
       end
     end
@@ -25,22 +25,8 @@ hosts.each do |host|
       end
 
       it 'writes the correct contents to the correct file' do
-        stdout = on(host, "cat #{hiera_datadir(host)}/default.yaml").stdout
+        stdout = on(host, "cat #{hiera_datadir(host)}/common.yaml").stdout
         expect(stdout).to eq("---\nfoo: bar\n")
-      end
-    end
-
-    context 'when the terminus is set' do
-      before(:all) { set_hieradata_on(host, "---\n", 'not-default') }
-      after(:all) { on(host, "rm -rf #{hiera_datadir(host)}") }
-
-      it 'creates the datadir' do
-        on host, "test -d #{hiera_datadir(host)}"
-      end
-
-      it 'writes the correct contents to the correct file' do
-        stdout = on(host, "cat #{hiera_datadir(host)}/not-default.yaml").stdout
-        expect(stdout).to eq("---\n")
       end
     end
   end


### PR DESCRIPTION
* Change InSpec to use the 'reporter' option instead of 'format'
* Update the SSG to point to the new ComplianceAsCode repository
* Deprecate the 'terminus' parameter in 'write_hieradata_to' and 'set_hieradata_on'
* Add 'copy_hiera_data_to' method to replace the one from beaker-hiera
* Add 'hiera_datadir' method to replace the one from beaker-hiera

This should be a seamless working update for existing SIMP modules