### PR TITLE
(SIMP-MAINT) Fall back to SSH if rsync doesn't work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.12.1 / 2018-10-24
+* Fall back to SSH file copies automatically when rsync does not work due to
+  test cases that affect ssh directly and that will cause new sessions to fail.
+
 ### 1.12.0 / 2018-10-22
 * When using suites, allow users to loop through multiple specified nodesets as
   a colon delimited list or loop through all nodesets by passing 'ALL'.

--- a/lib/simp/beaker_helpers.rb
+++ b/lib/simp/beaker_helpers.rb
@@ -68,7 +68,16 @@ module Simp::BeakerHelpers
 
       # End rsync hackery
 
-      rsync_to(sut, src, dest, _opts)
+      begin
+        rsync_to(sut, src, dest, _opts)
+      rescue
+        # Depending on what is getting tested, a new SSH session might not
+        # work. In this case, we fall back to SSH.
+        #
+        # The rsync failure is quite fast so this doesn't affect performance as
+        # much as shoving a bunch of data over the ssh session.
+        scp_to(sut, src, dest, opts)
+      end
     else
       scp_to(sut, src, dest, opts)
     end

--- a/lib/simp/beaker_helpers/version.rb
+++ b/lib/simp/beaker_helpers/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 module Simp::BeakerHelpers
-  VERSION = '1.12.0'
+  VERSION = '1.12.1'
 end


### PR DESCRIPTION
This has been causing issues on locked down system tests and the
potential performance hit is worth having tests that "just work"