### PR TITLE
(SIMP-MAINT) Add workaround for beaker-docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.13.1 / 2018-11-27
+* Add a work around for getting the docker SUT ID due to breaking changes in
+  the beaker-docker gem
+
 ### 1.13.0 / 2018-11-09
 * Make the SSG reporting consistent with the InSpec reporting
   * Thanks to Liz Nemsick for the original result processing code

--- a/lib/simp/beaker_helpers/inspec.rb
+++ b/lib/simp/beaker_helpers/inspec.rb
@@ -65,13 +65,13 @@ module Simp::BeakerHelpers
         Dir.chdir(tmpdir) do
           if @sut[:hypervisor] == 'docker'
             # Work around for breaking changes in beaker-docker
-            if host_hash[:docker_container]
-              container_id = host_hash[:docker_container].id
+            if @sut.host_hash[:docker_container]
+              container_id = @sut.host_hash[:docker_container].id
             else
-              container_id = host_hash[:docker_container_id]
+              container_id = @sut.host_hash[:docker_container_id]
             end
 
-            %x(docker cp "#{@sut.container_id}:#{sut_inspec_results}" .)
+            %x(docker cp "#{container_id}:#{sut_inspec_results}" .)
           else
             scp_from(@sut, sut_inspec_results, '.')
           end

--- a/lib/simp/beaker_helpers/inspec.rb
+++ b/lib/simp/beaker_helpers/inspec.rb
@@ -64,7 +64,14 @@ module Simp::BeakerHelpers
       begin
         Dir.chdir(tmpdir) do
           if @sut[:hypervisor] == 'docker'
-            %x(docker cp "#{@sut.host_hash[:docker_container].id}:#{sut_inspec_results}" .)
+            # Work around for breaking changes in beaker-docker
+            if host_hash[:docker_container]
+              container_id = host_hash[:docker_container].id
+            else
+              container_id = host_hash[:docker_container_id]
+            end
+
+            %x(docker cp "#{@sut.container_id}:#{sut_inspec_results}" .)
           else
             scp_from(@sut, sut_inspec_results, '.')
           end

--- a/lib/simp/beaker_helpers/version.rb
+++ b/lib/simp/beaker_helpers/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 module Simp::BeakerHelpers
-  VERSION = '1.13.0'
+  VERSION = '1.13.1'
 end


### PR DESCRIPTION
The data structure for the host_hash docker-related items that came out
of beaker-docker changed from a full Hash to disparate items so we need
to account for that change.