### PR TITLE
Fix beaker-docker support

### DIFF
--- a/lib/simp/beaker_helpers.rb
+++ b/lib/simp/beaker_helpers.rb
@@ -49,7 +49,13 @@ module Simp::BeakerHelpers
         end
       end
 
-      %x(tar #{exclude_list.join(' ')} -hcf - -C "#{File.dirname(src)}" "#{File.basename(src)}" | docker exec -i "#{sut.host_hash[:docker_container].id}" tar -C "#{dest}" -xf -)
+      # Work around for breaking changes in beaker-docker
+      if sut.host_hash[:docker_container]
+        container_id = sut.host_hash[:docker_container].id
+      else
+        container_id = sut.host_hash[:docker_container_id]
+      end
+      %x(tar #{exclude_list.join(' ')} -hcf - -C "#{File.dirname(src)}" "#{File.basename(src)}" | docker exec -i "#{container_id}" tar -C "#{dest}" -xf -)
     elsif @has_rsync && sut.check_for_command('rsync')
       # This makes rsync_to work like beaker and scp usually do
       exclude_hack = %(__-__' -L --exclude '__-__)

--- a/simp-beaker-helpers.gemspec
+++ b/simp-beaker-helpers.gemspec
@@ -31,11 +31,6 @@ Gem::Specification.new do |s|
   # TODO: Update this when we no longer support Ruby 2.1.9 (should be October 2018)
   s.add_runtime_dependency 'net-telnet', '~> 0.1.1'
 
-  # Because net-telnet dropped support for Ruby < 2.2.0
-  # TODO: Update this when we no longer support Ruby 2.1.9 (should be October 2018)
-  s.add_runtime_dependency 'rubocop', '~> 0.57.2'
-
-
   ### s.files = Dir['Rakefile', '{bin,lib,spec}/**/*', 'README*', 'LICENSE*'] & `git ls-files -z .`.split("\0")
   s.files       = `git ls-files`.split("\n")
   s.test_files  = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
Fix another instance related to the host_hash docker related items change as in #90 
Also, remove runtime rubocop dependency as nothing in the code seems to require it.