### PR TITLE
(SIMP-6097) Fix running STIG on CentOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-### 1.13.1 / 2018-11-27
+### 1.13.1 / 2019-02-06
+* Work around issue where the SSG doesn't build the STIG for CentOS any longer.
 * Add a work around for getting the docker SUT ID due to breaking changes in
   the beaker-docker gem
 

--- a/lib/simp/beaker_helpers/ssg.rb
+++ b/lib/simp/beaker_helpers/ssg.rb
@@ -277,6 +277,15 @@ module Simp::BeakerHelpers
         else
           on(@sut, %(cd scap-content; git checkout $(git describe --abbrev=0 --tags)))
         end
+
+        # Work around the issue where the profiles now strip out derivative
+        # content that isn't explicitlly approved for that OS. This means that
+        # we are unable to test CentOS builds against the STIG, etc...
+        #
+        # This isn't 100% correct but it's "good enough" for an automated CI
+        # environment to tell us if something is critically out of alignment.
+        on(@sut, %(cd scap-content/build-scripts; sed -i 's/ssg.build_derivatives.profile_handling/#ssg.build_derivatives.profile_handling/g' enable_derivatives.py))
+
         on(@sut, %(cd scap-content/build; cmake ../; make -j4 #{OS_INFO[@os][@os_rel]['ssg']['build_target']}-content && cp *ds.xml #{@scap_working_dir}))
       end
     end


### PR DESCRIPTION
Add a workaround for building the SSG content so that the STIG can be
run on CentOS again.

SIMP-6097 #close