### PR TITLE
(SIMP-6102) Ensure that SUTs have a FQDN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-### 1.13.1 / 2019-02-06
+### 1.13.1 / 2019-02-02
+* Ensure that SUTs have an FQDN set and not just a short hostname
 * Work around issue where the SSG doesn't build the STIG for CentOS any longer.
 * Add a work around for getting the docker SUT ID due to breaking changes in
   the beaker-docker gem

--- a/lib/simp/beaker_helpers.rb
+++ b/lib/simp/beaker_helpers.rb
@@ -376,7 +376,18 @@ module Simp::BeakerHelpers
     # We need to be able to flip between server and client without issue
     on sut, 'puppet resource group puppet gid=52'
     on sut, 'puppet resource user puppet comment="Puppet" gid="52" uid="52" home="/var/lib/puppet" managehome=true'
-    
+
+    # Make sure we have a domain on our host
+    current_domain = fact_on(sut, 'domain').strip
+    if current_domain.empty?
+      on(sut, 'echo `hostname`.beaker.test > /etc/hostname', :accept_all_exit_codes => true)
+      on(sut, 'hostname `cat /etc/hostname`', :accept_all_exit_codes => true)
+    end
+
+    if fact_on(sut, 'domain').strip.empty?
+      fail("Error: hosts must have an FQDN, got domain='#{current_domain}'")
+    end
+
     # This may not exist in docker so just skip the whole thing
     if sut.file_exist?('/etc/ssh')
       # SIMP uses a central ssh key location so we prep that spot in case we
@@ -409,7 +420,7 @@ module Simp::BeakerHelpers
         on(sut, %{if [ -f "#{src_file}" ]; then cp -a -f "#{src_file}" "#{tgt_file}" && chmod 644 "#{tgt_file}"; fi}, :silent => true)
       end
     end
-    
+
     # SIMP uses structured facts, therefore stringify_facts must be disabled
     unless ENV['BEAKER_stringify_facts'] == 'yes'
       on sut, 'puppet config set stringify_facts false'


### PR DESCRIPTION
Given the nature of our tests, all hosts should have an FQDN. Since this
only happens once, tests can reset to a short hostname if it is truly
necessary.

SIMP-6102 #close