### PR TITLE
(SIMP-6212) Add function to install simp deps repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 1.14.0 / 2019-04-08
-* Added function install_simp_deps_repo to install the simp dependency repo.
-  This will allow a central place for it to be updated in the future.
+* Added function install_simp_repo to install the simp online repos.
+  The will be configured and enabled.   To disable one or more of them
+  pass in an array of names to disable.
 
 ### 1.13.1 / 2019-02-02
 * Ensure that SUTs have an FQDN set and not just a short hostname

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.14.0 / 2019-04-08
+* Added function install_simp_deps_repo to install the simp dependency repo.
+  This will allow a central place for it to be updated in the future.
+
 ### 1.13.1 / 2019-02-02
 * Ensure that SUTs have an FQDN set and not just a short hostname
 * Work around issue where the SSG doesn't build the STIG for CentOS any longer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ### 1.14.0 / 2019-04-08
-* Added function install_simp_repo to install the simp online repos.
-  The will be configured and enabled.   To disable one or more of them
-  pass in an array of names to disable.
+* Added function, install_simp_repo, to install the simp online repos.
+  The repos are defined in a hash in the function. All the repos
+  will be configured and enabled.   To disable one or more of them pass
+  in an array of names of the repos to disable.
 
 ### 1.13.1 / 2019-02-02
 * Ensure that SUTs have an FQDN set and not just a short hostname

--- a/lib/simp/beaker_helpers/version.rb
+++ b/lib/simp/beaker_helpers/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 module Simp::BeakerHelpers
-  VERSION = '1.13.1'
+  VERSION = '1.14.0'
 end

--- a/spec/acceptance/suites/default/install_simp_deps_repo_spec.rb
+++ b/spec/acceptance/suites/default/install_simp_deps_repo_spec.rb
@@ -1,0 +1,71 @@
+require 'spec_helper_acceptance'
+
+hosts.each do |host|
+  describe '#write_hieradata_to' do
+    let (:default_repo_content)  { <<-EOF
+# SIMP Dependencies Yum Repository
+[simp_dependencies]
+name=simp-project-6_X_Dependencies
+gpgcheck=1
+enabled=1
+baseurl=https://packagecloud.io/simp-project/6_X_Dependencies/el/$releasever/$basearch
+gpgkey=https://raw.githubusercontent.com/NationalSecurityAgency/SIMP/master/GPGKEYS/RPM-GPG-KEY-SIMP
+       https://yum.puppet.com/RPM-GPG-KEY-puppetlabs
+       https://yum.puppet.com/RPM-GPG-KEY-puppet
+       https://apt.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG-96
+       https://artifacts.elastic.co/GPG-KEY-elasticsearch
+       https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana
+       https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
+sslverify=1
+sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+metadata_expire=300
+EOF
+    }
+    let (:nondefault_repo_content)  { <<-EOF
+# SIMP Dependencies Yum Repository
+[simp_dependencies]
+name=simp-project-7_X_dependencies
+gpgcheck=0
+enabled=1
+baseurl=https://packagecloud.io/simp-project/7_X_dependencies/el/$releasever/$basearch
+gpgkey=https://raw.githubusercontent.com/NationalSecurityAgency/SIMP/master/GPGKEYS/RPM-GPG-KEY-SIMP
+       https://yum.puppet.com/RPM-GPG-KEY-puppetlabs
+       https://yum.puppet.com/RPM-GPG-KEY-puppet
+       https://apt.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG-96
+       https://artifacts.elastic.co/GPG-KEY-elasticsearch
+       https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana
+       https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
+sslverify=1
+sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+metadata_expire=300
+EOF
+    }
+    context 'defailt settings' do
+      before(:all) { install_simp_deps_repo(host) }
+      after(:all) { on(host, "rm -rf /etc/yum.repos.d/simp_dependencies.repo") }
+
+      it 'creates the repo' do
+        on host, 'test -f /etc/yum.repos.d/simp_dependencies.repo'
+      end
+
+      it 'writes the correct contents to the correct file' do
+        stdout = on(host, 'cat /etc/yum.repos.d/simp_dependencies.repo').stdout
+        expect(stdout).to eq(default_repo_content)
+      end
+    end
+
+    context 'when passed a hash' do
+      before(:all) { install_simp_deps_repo(host, '7_X_dependencies', '0' ) }
+      after(:all) { on(host, "rm -rf /etc/yum.repos.d/simp_dependencies.repo") }
+
+      it 'creates the repo' do
+        on host, 'test -f /etc/yum.repos.d/simp_dependencies.repo'
+      end
+
+      it 'writes the correct contents to the correct file' do
+        stdout = on(host, 'cat /etc/yum.repos.d/simp_dependencies.repo').stdout
+        expect(stdout).to eq(nondefault_repo_content)
+      end
+    end
+  end
+end

--- a/spec/acceptance/suites/default/install_simp_deps_repo_spec.rb
+++ b/spec/acceptance/suites/default/install_simp_deps_repo_spec.rb
@@ -11,32 +11,33 @@ hosts.each do |host|
       before(:all) { install_simp_repos(host) }
 
       it 'creates the repo' do
-        on host, 'test -f /etc/yum.repos.d/simp6.repo'
-        on host, 'test -f /etc/yum.repos.d/simp6_deps.repo'
+        on host, 'test -f /etc/yum.repos.d/simp.repo'
+        on host, 'test -f /etc/yum.repos.d/simp_deps.repo'
       end
 
       it 'enables the correct repos' do
-        simp6info = on(host, '/usr/bin/yum repolist -v simp6 | grep ^Repo-status').stdout.strip
+        simp6info = on(host, '/usr/bin/yum repolist -v simp | grep ^Repo-status').stdout.strip
         expect(simp6info).to match(/.*Repo-status.*enabled.*/)
-        simp6depsinfo = on(host, 'yum repolist -v simp6_deps| grep ^Repo-status').stdout.strip
+        simp6depsinfo = on(host, 'yum repolist -v simp_deps| grep ^Repo-status').stdout.strip
         expect(simp6depsinfo).to match(/.*Repo-status.*enabled.*/)
       end
     end
 
     context 'when passed a disabled list ' do
-      before(:all) { install_simp_repos(host, ['simp6'] ) }
+      before(:all) { install_simp_repos(host, ['simp'] ) }
 
       it 'creates the repo' do
-        on host, 'test -f /etc/yum.repos.d/simp6.repo'
-        on host, 'test -f /etc/yum.repos.d/simp6_deps.repo'
+        on host, 'test -f /etc/yum.repos.d/simp.repo'
+        on host, 'test -f /etc/yum.repos.d/simp_deps.repo'
       end
 
       it 'enables the correct repos' do
-        simp6info = on(host, 'yum repolist -v simp6 | grep ^Repo-status').stdout.strip
+        simp6info = on(host, 'yum repolist -v simp | grep ^Repo-status').stdout.strip
         expect(simp6info).to match(/.*Repo-status.*disabled.*/)
-        simp6depsinfo = on(host, 'yum repolist -v simp6_deps| grep ^Repo-status').stdout.strip
+        simp6depsinfo = on(host, 'yum repolist -v simp_deps| grep ^Repo-status').stdout.strip
         expect(simp6depsinfo).to match(/.*Repo-status.*enabled.*/)
       end
     end
+
   end
 end

--- a/spec/acceptance/suites/default/install_simp_deps_repo_spec.rb
+++ b/spec/acceptance/suites/default/install_simp_deps_repo_spec.rb
@@ -2,69 +2,40 @@ require 'spec_helper_acceptance'
 
 hosts.each do |host|
   describe '#write_hieradata_to' do
-    let (:default_repo_content)  { <<-EOF
-# SIMP Dependencies Yum Repository
-[simp_dependencies]
-name=simp-project-6_X_Dependencies
-gpgcheck=1
-enabled=1
-baseurl=https://packagecloud.io/simp-project/6_X_Dependencies/el/$releasever/$basearch
-gpgkey=https://raw.githubusercontent.com/NationalSecurityAgency/SIMP/master/GPGKEYS/RPM-GPG-KEY-SIMP
-       https://yum.puppet.com/RPM-GPG-KEY-puppetlabs
-       https://yum.puppet.com/RPM-GPG-KEY-puppet
-       https://apt.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG-96
-       https://artifacts.elastic.co/GPG-KEY-elasticsearch
-       https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana
-       https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
-sslverify=1
-sslcacert=/etc/pki/tls/certs/ca-bundle.crt
-metadata_expire=300
-EOF
-    }
-    let (:nondefault_repo_content)  { <<-EOF
-# SIMP Dependencies Yum Repository
-[simp_dependencies]
-name=simp-project-7_X_dependencies
-gpgcheck=0
-enabled=1
-baseurl=https://packagecloud.io/simp-project/7_X_dependencies/el/$releasever/$basearch
-gpgkey=https://raw.githubusercontent.com/NationalSecurityAgency/SIMP/master/GPGKEYS/RPM-GPG-KEY-SIMP
-       https://yum.puppet.com/RPM-GPG-KEY-puppetlabs
-       https://yum.puppet.com/RPM-GPG-KEY-puppet
-       https://apt.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG-96
-       https://artifacts.elastic.co/GPG-KEY-elasticsearch
-       https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana
-       https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
-sslverify=1
-sslcacert=/etc/pki/tls/certs/ca-bundle.crt
-metadata_expire=300
-EOF
-    }
+
+    it 'should install yum utils' do
+      host.install_package('yum-utils')
+    end
+
     context 'defailt settings' do
-      before(:all) { install_simp_deps_repo(host) }
-      after(:all) { on(host, "rm -rf /etc/yum.repos.d/simp_dependencies.repo") }
+      before(:all) { install_simp_repos(host) }
 
       it 'creates the repo' do
-        on host, 'test -f /etc/yum.repos.d/simp_dependencies.repo'
+        on host, 'test -f /etc/yum.repos.d/simp6.repo'
+        on host, 'test -f /etc/yum.repos.d/simp6_deps.repo'
       end
 
-      it 'writes the correct contents to the correct file' do
-        stdout = on(host, 'cat /etc/yum.repos.d/simp_dependencies.repo').stdout
-        expect(stdout).to eq(default_repo_content)
+      it 'enables the correct repos' do
+        simp6info = on(host, '/usr/bin/yum repolist -v simp6 | grep ^Repo-status').stdout.strip
+        expect(simp6info).to match(/.*Repo-status.*enabled.*/)
+        simp6depsinfo = on(host, 'yum repolist -v simp6_deps| grep ^Repo-status').stdout.strip
+        expect(simp6depsinfo).to match(/.*Repo-status.*enabled.*/)
       end
     end
 
-    context 'when passed a hash' do
-      before(:all) { install_simp_deps_repo(host, '7_X_dependencies', '0' ) }
-      after(:all) { on(host, "rm -rf /etc/yum.repos.d/simp_dependencies.repo") }
+    context 'when passed a disabled list ' do
+      before(:all) { install_simp_repos(host, ['simp6'] ) }
 
       it 'creates the repo' do
-        on host, 'test -f /etc/yum.repos.d/simp_dependencies.repo'
+        on host, 'test -f /etc/yum.repos.d/simp6.repo'
+        on host, 'test -f /etc/yum.repos.d/simp6_deps.repo'
       end
 
-      it 'writes the correct contents to the correct file' do
-        stdout = on(host, 'cat /etc/yum.repos.d/simp_dependencies.repo').stdout
-        expect(stdout).to eq(nondefault_repo_content)
+      it 'enables the correct repos' do
+        simp6info = on(host, 'yum repolist -v simp6 | grep ^Repo-status').stdout.strip
+        expect(simp6info).to match(/.*Repo-status.*disabled.*/)
+        simp6depsinfo = on(host, 'yum repolist -v simp6_deps| grep ^Repo-status').stdout.strip
+        expect(simp6depsinfo).to match(/.*Repo-status.*enabled.*/)
       end
     end
   end


### PR DESCRIPTION
- added a function, install_simp_repos, that sets up the 
   simp  internet repos.  Using this through out
  tests will allow it to be updated in one place  should it ever change.
- add parameter that takes a list of names of simp repos to disable.
SIMP-6212  #comment  This fix is needed for pkg-r10k tests