### PR TITLE
(SIMP-MAINT) Bump default version to Puppet 5

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -98,21 +98,6 @@ default:
     - beaker
   <<: *cache_bundler
   <<: *setup_bundler_env
-  variables:
-    PUPPET_VERSION: '~> 4.10.10'
-  script:
-    - bundle exec rake spec_clean
-    - bundle exec rake beaker:suites[default]
-
-default-puppet5:
-  stage: acceptance
-  tags:
-    - beaker
-  <<: *cache_bundler
-  <<: *setup_bundler_env
-  variables:
-    PUPPET_VERSION: '~> 5.3'
-    BEAKER_PUPPET_COLLECTION: 'puppet5'
   script:
     - bundle exec rake spec_clean
     - bundle exec rake beaker:suites[default]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### 1.14.2 / 2019-05-16
+* Move the minimum supported puppet version to Puppet 5 since Puppet 4 has been
+  removed from the download servers completely. Beaker may re-add support for
+  the new location so not removing the mappings at this time.
+* Fixed a bug where a hash item was incorrect and not properly passing along
+  configuration items.
+
 ### 1.14.1 / 2019-04-15
 * Handle license acceptance option needed for new versions of inspec.
 

--- a/lib/simp/beaker_helpers.rb
+++ b/lib/simp/beaker_helpers.rb
@@ -19,7 +19,7 @@ module Simp::BeakerHelpers
   #
   # This is done so that we know if some new thing that we're using breaks the
   # oldest system that we support.
-  DEFAULT_PUPPET_AGENT_VERSION = '1.10.4'
+  DEFAULT_PUPPET_AGENT_VERSION = '~> 5.0'
 
   # We can't cache this because it may change during a run
   def fips_enabled(sut)
@@ -889,7 +889,7 @@ done
     return result
   end
 
-  # returns hash with :puppet_install_version, :beaker_puppet_collection,
+  # returns hash with :puppet_install_version, :puppet_collection,
   # and :puppet_install_type keys determined from environment variables,
   # host settings, and/or defaults
   #
@@ -916,7 +916,7 @@ done
           raise("Error: Puppet Collection '#{puppet_collection}' must match /puppet(\\d+)/")
         end
       else
-        puppet_agent_version = DEFAULT_PUPPET_AGENT_VERSION
+        puppet_agent_version = latest_puppet_agent_version_for(DEFAULT_PUPPET_AGENT_VERSION)
       end
     end
 
@@ -925,9 +925,10 @@ done
       puppet_collection = "puppet#{base_version}" if base_version >= 5
     end
 
-    { :puppet_install_version   => puppet_agent_version,
-      :beaker_puppet_collection => puppet_collection,
-      :puppet_install_type      => ENV.fetch('PUPPET_INSTALL_TYPE', 'agent')
+    {
+      :puppet_install_version => puppet_agent_version,
+      :puppet_collection      => puppet_collection,
+      :puppet_install_type    => ENV.fetch('PUPPET_INSTALL_TYPE', 'agent')
     }
   end
 
@@ -938,7 +939,7 @@ done
 
     # In case  Beaker needs this info internally
     ENV['PUPPET_INSTALL_VERSION'] = install_info[:puppet_install_version]
-    unless install_info[:puppet_collection].nil?
+    if install_info[:puppet_collection]
       ENV['BEAKER_PUPPET_COLLECTION'] = install_info[:puppet_collection]
     end
 

--- a/lib/simp/beaker_helpers/version.rb
+++ b/lib/simp/beaker_helpers/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 module Simp::BeakerHelpers
-  VERSION = '1.14.1'
+  VERSION = '1.14.2'
 end

--- a/spec/acceptance/suites/default/check_puppet_version_spec.rb
+++ b/spec/acceptance/suites/default/check_puppet_version_spec.rb
@@ -14,8 +14,8 @@ hosts.each do |host|
           expect(client_puppet_version.split('.').first).to eq(puppet_collection_version)
         end
       else
-        it 'should not be running puppet 5+' do
-          expect(client_puppet_version.split('.').first).to be < '5'
+        it 'should not be running puppet 5' do
+          expect(client_puppet_version.split('.').first).to eq '5'
         end
       end
     end

--- a/spec/lib/simp/beaker_helpers_spec.rb
+++ b/spec/lib/simp/beaker_helpers_spec.rb
@@ -103,20 +103,17 @@ describe 'Simp::BeakerHelpers' do
     end
 
     it 'uses defaults when no environment variables are set' do
-      expected = {
-      :puppet_install_version   => Simp::BeakerHelpers::DEFAULT_PUPPET_AGENT_VERSION,
-      :beaker_puppet_collection => nil,
-      :puppet_install_type      => 'agent'
-      }
-      expect( @helper.get_puppet_install_info ).to eq expected
+      expect( @helper.get_puppet_install_info[:puppet_install_version] ).to match(/^5\./)
+      expect( @helper.get_puppet_install_info[:puppet_collection] ).to eq('puppet5')
+      expect( @helper.get_puppet_install_info[:puppet_install_type] ).to eq('agent')
     end
 
     it 'extracts info from PUPPET_INSTALL_VERSION for Puppet 4' do
       ENV['PUPPET_INSTALL_VERSION']= '4.10.5'
       expected = {
-      :puppet_install_version   => '1.10.5',
-      :beaker_puppet_collection => nil,
-      :puppet_install_type      => 'agent'
+        :puppet_install_version => '1.10.5',
+        :puppet_collection      => nil,
+        :puppet_install_type    => 'agent'
       }
       expect( @helper.get_puppet_install_info ).to eq expected
     end
@@ -125,9 +122,9 @@ describe 'Simp::BeakerHelpers' do
       allow(@helper).to receive(:`).with('gem search -ra -e puppet').and_return(gem_search_results)
       ENV['PUPPET_INSTALL_VERSION']= '5.5.0'
       expected = {
-      :puppet_install_version   => '5.5.0',
-      :beaker_puppet_collection => 'puppet5',
-      :puppet_install_type      => 'agent'
+        :puppet_install_version   => '5.5.0',
+        :puppet_collection => 'puppet5',
+        :puppet_install_type      => 'agent'
       }
       expect( @helper.get_puppet_install_info ).to eq expected
     end
@@ -137,9 +134,9 @@ describe 'Simp::BeakerHelpers' do
       ENV['PUPPET_INSTALL_VERSION']= '5.5.0'
       ENV['BEAKER_PUPPET_COLLECTION']= 'puppet6'
       expected = {
-      :puppet_install_version   => '5.5.0',
-      :beaker_puppet_collection => 'puppet5',
-      :puppet_install_type      => 'agent'
+        :puppet_install_version   => '5.5.0',
+        :puppet_collection => 'puppet5',
+        :puppet_install_type      => 'agent'
       }
       expect( @helper.get_puppet_install_info ).to eq expected
     end
@@ -149,9 +146,9 @@ describe 'Simp::BeakerHelpers' do
       ENV['PUPPET_INSTALL_VERSION']= '5.5.0'
       @helper.host.options = {'puppet_collection' => 'puppet6'}
       expected = {
-      :puppet_install_version   => '5.5.0',
-      :beaker_puppet_collection => 'puppet5',
-      :puppet_install_type      => 'agent'
+        :puppet_install_version   => '5.5.0',
+        :puppet_collection => 'puppet5',
+        :puppet_install_type      => 'agent'
       }
       expect( @helper.get_puppet_install_info ).to eq expected
     end
@@ -159,9 +156,9 @@ describe 'Simp::BeakerHelpers' do
     it 'extracts info from BEAKER_PUPPET_AGENT_VERSION' do
       ENV['BEAKER_PUPPET_AGENT_VERSION']= '4.10.5'
       expected = {
-      :puppet_install_version   => '1.10.5',
-      :beaker_puppet_collection => nil,
-      :puppet_install_type      => 'agent'
+        :puppet_install_version   => '1.10.5',
+        :puppet_collection => nil,
+        :puppet_install_type      => 'agent'
       }
       expect( @helper.get_puppet_install_info ).to eq expected
     end
@@ -169,9 +166,9 @@ describe 'Simp::BeakerHelpers' do
     it 'extracts info from PUPPET_VERSION' do
       ENV['PUPPET_VERSION']= '4.10.5'
       expected = {
-      :puppet_install_version   => '1.10.5',
-      :beaker_puppet_collection => nil,
-      :puppet_install_type      => 'agent'
+        :puppet_install_version   => '1.10.5',
+        :puppet_collection => nil,
+        :puppet_install_type      => 'agent'
       }
       expect( @helper.get_puppet_install_info ).to eq expected
     end
@@ -180,9 +177,9 @@ describe 'Simp::BeakerHelpers' do
       allow(@helper).to receive(:`).with('gem search -ra -e puppet').and_return(gem_search_results)
       ENV['BEAKER_PUPPET_COLLECTION']= 'puppet5'
       expected = {
-      :puppet_install_version   => '5.5.1',
-      :beaker_puppet_collection => 'puppet5',
-      :puppet_install_type      => 'agent'
+        :puppet_install_version   => '5.5.1',
+        :puppet_collection => 'puppet5',
+        :puppet_install_type      => 'agent'
       }
       expect( @helper.get_puppet_install_info ).to eq expected
     end
@@ -191,21 +188,19 @@ describe 'Simp::BeakerHelpers' do
       allow(@helper).to receive(:`).with('gem search -ra -e puppet').and_return(gem_search_results)
       @helper.host.options = {'puppet_collection' => 'puppet5'}
       expected = {
-      :puppet_install_version   => '5.5.1',
-      :beaker_puppet_collection => 'puppet5',
-      :puppet_install_type      => 'agent'
+        :puppet_install_version   => '5.5.1',
+        :puppet_collection => 'puppet5',
+        :puppet_install_type      => 'agent'
       }
       expect( @helper.get_puppet_install_info ).to eq expected
     end
 
     it 'extracts info from PUPPET_INSTALL_TYPE' do
       ENV['PUPPET_INSTALL_TYPE'] = 'pe'
-      expected = {
-      :puppet_install_version   => Simp::BeakerHelpers::DEFAULT_PUPPET_AGENT_VERSION,
-      :beaker_puppet_collection => nil,
-      :puppet_install_type      => 'pe'
-      }
-      expect( @helper.get_puppet_install_info ).to eq expected
+
+      expect( @helper.get_puppet_install_info[:puppet_collection] ).to eq('puppet5')
+      expect( @helper.get_puppet_install_info[:puppet_install_type] ).to eq('pe')
+      expect( @helper.get_puppet_install_info[:puppet_install_version] ).to match(/^5\./)
     end
 
     it 'fails when BEAKER_PUPPET_COLLECTION is invalid' do

--- a/spec/lib/simp/beaker_helpers_spec.rb
+++ b/spec/lib/simp/beaker_helpers_spec.rb
@@ -123,7 +123,7 @@ describe 'Simp::BeakerHelpers' do
       ENV['PUPPET_INSTALL_VERSION']= '5.5.0'
       expected = {
         :puppet_install_version   => '5.5.0',
-        :puppet_collection => 'puppet5',
+        :puppet_collection        => 'puppet5',
         :puppet_install_type      => 'agent'
       }
       expect( @helper.get_puppet_install_info ).to eq expected
@@ -135,7 +135,7 @@ describe 'Simp::BeakerHelpers' do
       ENV['BEAKER_PUPPET_COLLECTION']= 'puppet6'
       expected = {
         :puppet_install_version   => '5.5.0',
-        :puppet_collection => 'puppet5',
+        :puppet_collection        => 'puppet5',
         :puppet_install_type      => 'agent'
       }
       expect( @helper.get_puppet_install_info ).to eq expected
@@ -147,7 +147,7 @@ describe 'Simp::BeakerHelpers' do
       @helper.host.options = {'puppet_collection' => 'puppet6'}
       expected = {
         :puppet_install_version   => '5.5.0',
-        :puppet_collection => 'puppet5',
+        :puppet_collection        => 'puppet5',
         :puppet_install_type      => 'agent'
       }
       expect( @helper.get_puppet_install_info ).to eq expected
@@ -157,7 +157,7 @@ describe 'Simp::BeakerHelpers' do
       ENV['BEAKER_PUPPET_AGENT_VERSION']= '4.10.5'
       expected = {
         :puppet_install_version   => '1.10.5',
-        :puppet_collection => nil,
+        :puppet_collection        => nil,
         :puppet_install_type      => 'agent'
       }
       expect( @helper.get_puppet_install_info ).to eq expected
@@ -167,7 +167,7 @@ describe 'Simp::BeakerHelpers' do
       ENV['PUPPET_VERSION']= '4.10.5'
       expected = {
         :puppet_install_version   => '1.10.5',
-        :puppet_collection => nil,
+        :puppet_collection        => nil,
         :puppet_install_type      => 'agent'
       }
       expect( @helper.get_puppet_install_info ).to eq expected
@@ -178,7 +178,7 @@ describe 'Simp::BeakerHelpers' do
       ENV['BEAKER_PUPPET_COLLECTION']= 'puppet5'
       expected = {
         :puppet_install_version   => '5.5.1',
-        :puppet_collection => 'puppet5',
+        :puppet_collection        => 'puppet5',
         :puppet_install_type      => 'agent'
       }
       expect( @helper.get_puppet_install_info ).to eq expected
@@ -189,7 +189,7 @@ describe 'Simp::BeakerHelpers' do
       @helper.host.options = {'puppet_collection' => 'puppet5'}
       expected = {
         :puppet_install_version   => '5.5.1',
-        :puppet_collection => 'puppet5',
+        :puppet_collection        => 'puppet5',
         :puppet_install_type      => 'agent'
       }
       expect( @helper.get_puppet_install_info ).to eq expected


### PR DESCRIPTION
This is an emergency fix to handle the rearrangement of the upstream
puppet repositories.

The default version is now pinned to the latest Puppet 5