### PR TITLE
(SIMP-MAINT) Add missing GPG key to SIMP deps repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.14.3 / 2019-06-24
+* Add RPM-GPG-KEY-SIMP-6 to the SIMP dependencies repo created
+  by install_simp_repo.
+
 ### 1.14.2 / 2019-05-16
 * Move the minimum supported puppet version to Puppet 5 since Puppet 4 has been
   removed from the download servers completely. Beaker may re-add support for

--- a/lib/simp/beaker_helpers.rb
+++ b/lib/simp/beaker_helpers.rb
@@ -978,6 +978,7 @@ done
       'simp_deps' => {
         :baseurl   => 'https://packagecloud.io/simp-project/6_X_Dependencies/el/$releasever/$basearch',
         :gpgkey    => ['https://raw.githubusercontent.com/NationalSecurityAgency/SIMP/master/GPGKEYS/RPM-GPG-KEY-SIMP',
+                    'https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP-6',
                     'https://yum.puppet.com/RPM-GPG-KEY-puppetlabs',
                     'https://yum.puppet.com/RPM-GPG-KEY-puppet',
                     'https://apt.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG-96',

--- a/lib/simp/beaker_helpers/version.rb
+++ b/lib/simp/beaker_helpers/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 module Simp::BeakerHelpers
-  VERSION = '1.14.2'
+  VERSION = '1.14.3'
 end


### PR DESCRIPTION
Added RPM-GPG-KEY-SIMP-6 to the SIMP dependencies repo created
by install_simp_repo().