### PR TITLE
(SIMP-MAINT) Bump HighLine version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.14.4 / 2019-07-26
+* Bump the version of Highline to 2.0+ due to bugs in the latest 1.X series
+
 ### 1.14.3 / 2019-06-24
 * Add RPM-GPG-KEY-SIMP-6 to the SIMP dependencies repo created
   by install_simp_repo.

--- a/lib/simp/beaker_helpers/version.rb
+++ b/lib/simp/beaker_helpers/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 module Simp::BeakerHelpers
-  VERSION = '1.14.3'
+  VERSION = '1.14.4'
 end

--- a/simp-beaker-helpers.gemspec
+++ b/simp-beaker-helpers.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'beaker-docker'               , '~> 0.3'
   s.add_runtime_dependency 'beaker-vagrant'              , '~> 0.5'
   s.add_runtime_dependency 'beaker-puppet_install_helper', '~> 0.9'
-  s.add_runtime_dependency 'highline'                    , '~> 1.6'
+  s.add_runtime_dependency 'highline'                    , '~> 2.0'
   s.add_runtime_dependency 'nokogiri'                    , '~> 1.8'
 
   # Because net-telnet dropped support for Ruby < 2.3.0


### PR DESCRIPTION
* Bump the version of Highline to 2.0+ due to bugs in the latest 1.X series