### PR TITLE
(SIMP-6916) Add Windows client support to the beaker helpers functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### 1.14.6 / 2019-08-15
+* Add Windows client support to the beaker helpers functions
+  * Added an `is_windows?(sut)` function
+  * Work around issues with calling `sut.puppet` on Windows SUTs
+  * Update `copy_fixture_modules_to` to support Windows (slow copy)
+  * Add Windows support to `puppet_modulepath_on`
+
 ### 1.14.5 / 2019-08-14
 * Update the CentOS SSG hooks to properly work with CentOS 6
 

--- a/lib/simp/beaker_helpers.rb
+++ b/lib/simp/beaker_helpers.rb
@@ -19,9 +19,7 @@ module Simp::BeakerHelpers
   end
 
   def is_windows?(sut)
-    @is_windows ||= fact_on(sut, 'osfamily').casecmp?('windows')
-
-    @is_windows
+    fact_on(sut, 'osfamily').casecmp?('windows')
   end
 
   # We can't cache this because it may change during a run

--- a/lib/simp/beaker_helpers/version.rb
+++ b/lib/simp/beaker_helpers/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 module Simp::BeakerHelpers
-  VERSION = '1.14.5'
+  VERSION = '1.14.6'
 end


### PR DESCRIPTION
* Added an `is_windows?(sut)` function
* Work around issues with calling `sut.puppet` on Windows SUTs
* Update `copy_fixture_modules_to` to support Windows (slow copy)
* Add Windows support to `puppet_modulepath_on`

SIMP-6916 #comment Update simp-beaker-helpers to support Windows