### PR TITLE
(SIMP-6708) Fix inspec report processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.15.2 / 2019-09-13
+* Fix an issue where the inspec reports were not processed properly
+
 ### 1.15.1 / 2019-08-26
 * Ensure that any user on the SUT can use the RedHat entitlements
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Methods to assist beaker acceptance tests for SIMP.
     * [PUPPET_VERSION](#puppet_version)
     * [BEAKER_RHSM_USER](#beaker_rhsm_user)
     * [BEAKER_RHSM_PASS](#beaker_rhsm_pass)
+    * [BEAKER_inspec_version](#beaker_inspec_version)
 * [Examples](#examples)
   * [Prep OS, Generate and copy PKI certs to each SUT](#prep-os-generate-and-copy-pki-certs-to-each-sut)
   * [Specify the version of Puppet to run in the SUTs](#specify-the-version-of-puppet-to-run-in-the-suts)
@@ -399,6 +400,13 @@ Will not be output to the screen.
 
 Note:  When using Subscription Manager, make sure your nodeset has the setting validation: false.   Otherwise Beaker:Rspec
 might try to install packages before subscription manager is configured.
+
+#### BEAKER_inspec_version
+
+The version of InSpec to use when running inspec tests. Currently hard-coded to
+`4.16.14` due to a bug introduced in `4.16.15`.
+
+Let to 'latest' to use the latest available in the upstream repos.
 
 ## Examples
 

--- a/lib/simp/beaker_helpers/inspec.rb
+++ b/lib/simp/beaker_helpers/inspec.rb
@@ -196,31 +196,59 @@ module Simp::BeakerHelpers
 
           next unless title
 
-          stats[:profiles][profile_name][:controls][title] = {}
+          base_title = title.scan(/.{1,60}\W|.{1,60}/).map(&:strip).join("\n           ")
 
-          formatted_title = title.scan(/.{1,72}\W|.{1,72}/).map(&:strip).join("\n           ")
+          if control['results'] && (control['results'].size > 1)
+            control['results'].each do |result|
+              control_title = " => { #{result['code_desc']} }"
 
-          stats[:profiles][profile_name][:controls][title][:formatted_title] = formatted_title
+              full_title = title + control_title
+              formatted_title = base_title + control_title
 
-          if control['results'] && !control['results'].empty?
-            status = control['results'].first['status']
+              stats[:profiles][profile_name][:controls][full_title] = {}
 
-            if status == /^fail/
-              status = :failed
-              color = 'red'
-            else
-              status = :passed
-              color = 'green'
+              stats[:profiles][profile_name][:controls][full_title][:formatted_title] = formatted_title
+
+              if result['status'] =~ /^fail/
+                status = :failed
+                color = 'red'
+              else
+                status = :passed
+                color = 'green'
+              end
+
+              stats[:global][status] << formatted_title.color
+
+              stats[:profiles][profile_name][:controls][full_title][:status] = status
+              stats[:profiles][profile_name][:controls][full_title][:source] = control['source_location']['ref']
             end
           else
-            status = :skipped
-            color = 'yellow'
+            formatted_title = base_title
+
+            stats[:profiles][profile_name][:controls][title] = {}
+
+            stats[:profiles][profile_name][:controls][title][:formatted_title] = formatted_title
+
+            if control['results'] && !control['results'].empty?
+              status = :passed
+              color = 'green'
+
+              control['results'].each do |result|
+                if results['status'] =~ /^fail/
+                  status = :failed
+                  color = 'red'
+                end
+              end
+
+            else
+              status = :skipped
+            end
+
+            stats[:global][status] << formatted_title.color
+
+            stats[:profiles][profile_name][:controls][title][:status] = status
+            stats[:profiles][profile_name][:controls][title][:source] = control['source_location']['ref']
           end
-
-          stats[:global][status] << title.to_s.color
-
-          stats[:profiles][profile_name][:controls][title][:status] = status
-          stats[:profiles][profile_name][:controls][title][:source] = control['source_location']['ref']
         end
       end
 

--- a/lib/simp/beaker_helpers/inspec.rb
+++ b/lib/simp/beaker_helpers/inspec.rb
@@ -19,9 +19,17 @@ module Simp::BeakerHelpers
     #   The name of the profile against which to run
     #
     def initialize(sut, profile)
+      @inspec_version = ENV['BEAKER_inspec_version'] || '4.16.14'
+
       @sut = sut
 
-      @sut.install_package('inspec')
+      @sut.install_package('git')
+
+      if @inspec_version == 'latest'
+        @sut.install_package('inspec')
+      else
+        @sut.install_package("inspec-#{@inspec_version}")
+      end
 
       os = fact_on(@sut, 'operatingsystem')
       os_rel = fact_on(@sut, 'operatingsystemmajrelease')
@@ -179,6 +187,9 @@ module Simp::BeakerHelpers
       end
 
       if !profiles || profiles.empty?
+      require 'pry'
+      binding.pry
+
         fail("Error: Could not find 'profiles' in the passed results")
       end
 

--- a/lib/simp/beaker_helpers/version.rb
+++ b/lib/simp/beaker_helpers/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 module Simp::BeakerHelpers
-  VERSION = '1.15.1'
+  VERSION = '1.15.2'
 end


### PR DESCRIPTION
The inspec report processor was not processing all sub-controls for a
given test. In the past, this was due to the in-flux nature of the
inspec reports themselves. The latest releases of inspec seem to have
stabilized and can now be easily, and completely processed.

SIMP-6708 #comment fix simp-beaker-helpers bug discovered during testing