### PR TITLE
(SIMP-7224) Optionally hide puppet-only tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ### 1.17.1 / 2019-11-1
-* Hide puppet-only tasks when not working on a puppet module
+* Only pull in the beaker rake tasks from the puppetlabs helpers
 
 ### 1.17.0 / 2019-10-22
 * Allow users to perform exclusion filters on SSG results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.17.1 / 2019-11-1
+* Hide puppet-only tasks when not working on a puppet module
+
 ### 1.17.0 / 2019-10-22
 * Allow users to perform exclusion filters on SSG results
 * Allow users to pass Arrays of items to match for SSG results

--- a/Rakefile
+++ b/Rakefile
@@ -12,10 +12,6 @@ require 'simp/rake/beaker'
 
 Simp::Rake::Beaker.new(@rakefile_dir)
 
-['spec','syntax','syntax:hiera','syntax:manifests','syntax:templates','lint','metadata'].each do |task|
-  Rake::Task[task].clear
-end
-
 CLEAN.include "#{@package}-*.gem"
 CLEAN.include 'pkg'
 CLEAN.include 'dist'

--- a/lib/simp/beaker_helpers/version.rb
+++ b/lib/simp/beaker_helpers/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 module Simp::BeakerHelpers
-  VERSION = '1.17.0'
+  VERSION = '1.17.1'
 end

--- a/lib/simp/rake/beaker.rb
+++ b/lib/simp/rake/beaker.rb
@@ -4,6 +4,31 @@ require 'rake/tasklib'
 require 'fileutils'
 require 'puppetlabs_spec_helper/rake_tasks'
 
+unless File.exists?('metadata.json')
+  # This is something just using beaker that wants the special sauce. In this
+  # case, we really don't want things that only have to do with puppet modules.
+  keep_tasks = [
+    '^spec$',
+    '^spec_',
+    '^rubocop',
+    '^parallel_',
+    '^beaker'
+  ].map{|x| Regexp.new(x)}
+
+  Rake::Task.tasks.each do |task|
+    unless keep_tasks.any?{ |regexp| regexp.match?(task.name) }
+      # Clearing the comments ensures that the tasks still exist but don't
+      # actually show up in the output of `rake -T`.
+      #
+      # You can still see them if you add `-A` and any future declaration of a
+      # task with the same name will generally do what the user wants. It's not
+      # perfect, but it does provide a better user experience when using the
+      # library with items that are not puppet modules.
+      task.clear_comments
+    end
+  end
+end
+
 module Simp; end
 module Simp::Rake
   class Beaker < ::Rake::TaskLib

--- a/lib/simp/rake/beaker.rb
+++ b/lib/simp/rake/beaker.rb
@@ -2,32 +2,7 @@ require 'rake'
 require 'rake/clean'
 require 'rake/tasklib'
 require 'fileutils'
-require 'puppetlabs_spec_helper/rake_tasks'
-
-unless File.exists?('metadata.json')
-  # This is something just using beaker that wants the special sauce. In this
-  # case, we really don't want things that only have to do with puppet modules.
-  keep_tasks = [
-    '^spec$',
-    '^spec_',
-    '^rubocop',
-    '^parallel_',
-    '^beaker'
-  ].map{|x| Regexp.new(x)}
-
-  Rake::Task.tasks.each do |task|
-    unless keep_tasks.any?{ |regexp| regexp.match?(task.name) }
-      # Clearing the comments ensures that the tasks still exist but don't
-      # actually show up in the output of `rake -T`.
-      #
-      # You can still see them if you add `-A` and any future declaration of a
-      # task with the same name will generally do what the user wants. It's not
-      # perfect, but it does provide a better user experience when using the
-      # library with items that are not puppet modules.
-      task.clear_comments
-    end
-  end
-end
+require 'puppetlabs_spec_helper/tasks/beaker'
 
 module Simp; end
 module Simp::Rake


### PR DESCRIPTION
Hide puppet-only tasks when not working on a puppet module to make the
usage less confusing to other usages.

SIMP-7224 #close