### PR TITLE
(SIMP-MAINT) Fix Windows library loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 1.18.1 / 2020-02-12
 * Fix gemspec dependencies
+* Fix the windows library loading location
 
 ### 1.18.0 / 2020-02-06
 * Update Windows support

--- a/lib/simp/beaker_helpers.rb
+++ b/lib/simp/beaker_helpers.rb
@@ -11,6 +11,7 @@ module Simp::BeakerHelpers
   require 'simp/beaker_helpers/snapshot'
   require 'simp/beaker_helpers/ssg'
   require 'simp/beaker_helpers/version'
+  require 'simp/beaker_helpers/windows'
 
   # Stealing this from the Ruby 2.5 Dir::Tmpname workaround from Rails
   def self.tmpname
@@ -18,9 +19,7 @@ module Simp::BeakerHelpers
     "simp-beaker-helpers-#{t}-#{$$}-#{rand(0x100000000).to_s(36)}.tmp"
   end
 
-  def is_windows?(sut)
-    is_windows = fact_on(sut, 'osfamily').casecmp?('windows')
-
+  def load_windows_requirements
     if is_windows
       begin
         require 'beaker-windows'
@@ -36,6 +35,10 @@ module Simp::BeakerHelpers
     end
 
     return is_windows
+  end
+
+  def is_windows?(sut)
+    is_windows = fact_on(sut, 'osfamily').casecmp?('windows')
   end
 
   # We can't cache this because it may change during a run

--- a/lib/simp/beaker_helpers/version.rb
+++ b/lib/simp/beaker_helpers/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 module Simp::BeakerHelpers
-  VERSION = '1.18.1'
+  VERSION = '1.18.2'
 end

--- a/lib/simp/beaker_helpers/windows.rb
+++ b/lib/simp/beaker_helpers/windows.rb
@@ -1,0 +1,16 @@
+module Simp; end
+module Simp::BeakerHelpers; end
+
+module Simp::BeakerHelpers::Windows
+  begin
+    require 'beaker-windows'
+  rescue LoadError
+    logger.error(%{You must include 'beaker-windows' in your Gemfile for windows support})
+    exit 1
+  end
+
+  include BeakerWindows::Path
+  include BeakerWindows::Powershell
+  include BeakerWindows::Registry
+  include BeakerWindows::WindowsFeature
+end

--- a/simp-beaker-helpers.gemspec
+++ b/simp-beaker-helpers.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
                }
   s.add_runtime_dependency 'beaker'                      , ['>= 4.16.0', '< 5.0.0']
   s.add_runtime_dependency 'beaker-rspec'                , '~> 6.2'
-  s.add_runtime_dependency 'beaker-puppet'               , ['>= 1.18.12', '< 2.0.0']
+  s.add_runtime_dependency 'beaker-puppet'               , ['>= 1.18.13', '< 2.0.0']
   s.add_runtime_dependency 'beaker-docker'               , '~> 0.3'
   s.add_runtime_dependency 'beaker-vagrant'              , ['>= 0.6.4', '< 2.0.0']
   s.add_runtime_dependency 'beaker-puppet_install_helper', '~> 0.9'

--- a/simp-beaker-helpers.gemspec
+++ b/simp-beaker-helpers.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |s|
   s.metadata = {
                  'issue_tracker' => 'https://simp-project.atlassian.net'
                }
-  s.add_runtime_dependency 'beaker'                      , ['>= 4.16.0', '< 5.0.0']
+  s.add_runtime_dependency 'beaker'                      , ['>= 4.17.0', '< 5.0.0']
   s.add_runtime_dependency 'beaker-rspec'                , '~> 6.2'
-  s.add_runtime_dependency 'beaker-puppet'               , ['>= 1.18.13', '< 2.0.0']
+  s.add_runtime_dependency 'beaker-puppet'               , ['>= 1.18.14', '< 2.0.0']
   s.add_runtime_dependency 'beaker-docker'               , '~> 0.3'
   s.add_runtime_dependency 'beaker-vagrant'              , ['>= 0.6.4', '< 2.0.0']
   s.add_runtime_dependency 'beaker-puppet_install_helper', '~> 0.9'


### PR DESCRIPTION
The previous location for loading the Windows libraries would not work
in a `:before` block. This moves it into its own module space.