### PR TITLE
Fix default nodeset

### DIFF
--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -13,6 +13,7 @@ HOSTS:
       - master
       - el7
     platform: el-7-x86_64
+    packaging_platform: el-7-x86_64
     box: centos/7
     hypervisor: <%= hypervisor %>
 
@@ -20,6 +21,7 @@ HOSTS:
     roles:
       - el6
     platform: el-6-x86_64
+    packaging_platform: el-6-x86_64
     box: centos/6
     hypervisor: <%= hypervisor %>
 


### PR DESCRIPTION
This commit adds the correct `packaging_platform` variables to the
default nodesets for Beaker acceptance tests.