### PR TITLE
(SIMP-MAINT) Add network info helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.19.3 / 2020-03-17
+* Add two network-related helpers:  host_networks() and internal_network_info()
+
 ### 1.18.3 / 2020-02-24
 * Fix the Windows library loading location.
   * No longer attempt to load windows libraries by default unless the system is

--- a/lib/simp/beaker_helpers.rb
+++ b/lib/simp/beaker_helpers.rb
@@ -11,6 +11,9 @@ module Simp::BeakerHelpers
   require 'simp/beaker_helpers/snapshot'
   require 'simp/beaker_helpers/ssg'
   require 'simp/beaker_helpers/version'
+  require 'simp/beaker_helpers/network'
+
+  include Simp::BeakerHelpers::Network
 
   # Stealing this from the Ruby 2.5 Dir::Tmpname workaround from Rails
   def self.tmpname

--- a/lib/simp/beaker_helpers/network.rb
+++ b/lib/simp/beaker_helpers/network.rb
@@ -1,0 +1,62 @@
+module Simp; end
+module Simp::BeakerHelpers; end
+
+module Simp::BeakerHelpers::Network
+
+  # @returns array of IPV4 networks configured on a host or nil
+  #   if none can be determined
+  #
+  # NOTE:
+  # - Result can be used for simp_options::trusted_nets in a test.
+  # - Uses the modern 'networking' fact from the puppet-agent RPM.
+  #
+  # @param host [Host] the host whose networks info is to be retrieved
+  #
+  def host_networks(host)
+    require 'json'
+    require 'ipaddr'
+    networks = nil
+    networking = JSON.load(on(host, 'facter --json networking').stdout)
+    if networking.key?('networking') && networking['networking'].key?('interfaces')
+      networking['networking']['interfaces'].delete_if { |key,value| key == 'lo' }
+      networks = networking['networking']['interfaces'].map do |key,value|
+        net_mask = IPAddr.new(value['netmask']).to_i.to_s(2).count('1')
+        "#{value['network']}/#{net_mask}"
+      end
+    end
+
+    networks
+  end
+
+  # @returns the internal IPV4 network info for a host or nil if
+  #   none can be determined
+  #
+  # NOTES:
+  # - Uses the modern 'networking' fact from the puppet-agent RPM.
+  # - This method ASSUMES the first non-loopback interface without DHCP
+  #   configured or with DHCP that does not matches the outermost 'dhcp'
+  #   key is the interface used for the internal network.
+  #
+  # @param host [Host] the host whose internal network info is to be retrieved
+  #
+  def internal_network_info(host)
+    networking = JSON.load(on(host, 'facter --json networking').stdout)
+    internal_ip_info = nil
+    if networking.key?('networking') && networking['networking'].key?('interfaces')
+      main_dhcp = networking['networking']['dhcp']
+      networking['networking']['interfaces'].each do |interface,settings|
+        next if interface == 'lo'
+        if ( ! settings.has_key?('dhcp') || (settings['dhcp'] != main_dhcp ) )
+          internal_ip_info = {
+            :interface => interface,
+            :ip        => settings['ip'],
+            :netmask   => settings['netmask']
+          }
+          break
+        end
+      end
+    end
+
+    internal_ip_info
+  end
+end

--- a/lib/simp/beaker_helpers/version.rb
+++ b/lib/simp/beaker_helpers/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 module Simp::BeakerHelpers
-  VERSION = '1.18.3'
+  VERSION = '1.19.0'
 end

--- a/spec/acceptance/suites/default/network_info_spec.rb
+++ b/spec/acceptance/suites/default/network_info_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper_acceptance'
+
+hosts.each do |host|
+  describe '#host_networks' do
+    it 'returns networks' do
+      networks = host_networks(host)
+      puts "networks = #{networks.inspect}"
+
+      expect(networks).to_not be_nil
+      expect(networks).to be_an(Array)
+      expect(networks).to_not be_empty
+    end
+  end
+
+  describe '#internal_network_info' do
+    it 'returns internal network info' do
+      internal_network = internal_network_info(host)
+      puts "internal_network = #{internal_network.inspect}"
+
+      expect(internal_network).to_not be_nil
+      expect(internal_network).to be_a(Hash)
+      expect(internal_network).to_not be_empty
+
+      [:interface, :ip, :netmask].each do |key|
+        expect(internal_network[key]).to_not be_nil
+        expect(internal_network[key].strip).to_not be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add two network-related helpers:
- host_networks(): Useful to set simp_options::trusted_nets to
  actual test networks, in lieu of 'ALL'. This has helped to
  uncover bugs!
- internal_network_info(): Useful for manifests that need to
  use a host's IP address, not its FQDN, and you are not sure
  which network device is in use on the private network.

Both of these are used in simp-core and NFS-related tests.