### PR TITLE
[SIMP-MAINT] Allow different versions of beaker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.18.8 / 2020-07-14
+* Allow the beaker version to be pinned by environment variable
+
 ### 1.18.7 / 2020-07-07
 * Fix host reference bug when switching to FIPS mode
 * Ensure that net-ssh 6+ can access older FIPS systems

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,34 @@ gem 'bundler'
 gem 'rake'
 
 group :system_tests do
-  gem 'beaker'
+  beaker_gem_options = ENV.fetch('BEAKER_GEM_OPTIONS', ['>= 4.17.0', '< 5.0.0'])
+
+  if "#{beaker_gem_options}".include?(':')
+    # Just pass in BEAKER_GEM_OPTIONS as a string that would represent the usual
+    # hash of options.
+    #
+    # Something like: BEAKER_GEM_OPTIONS=':git => "https://my.repo/beaker.git", :tag => "1.2.3"'
+    #
+    # No, this isn't robust, but it's not really an 'every day' sort of thing
+    # and safer than an `eval`
+    begin
+      gem 'beaker', Hash[
+        beaker_gem_options.split(',').map do |x| # Split passed options on k/v pairs
+          x.strip.split(/:\s|\s+=>\s+/) # Allow for either format hash keys
+        end.map do |k,v|
+          [
+            k.delete(':').to_sym, # Convert all keys to symbols
+            v.strip
+          ]
+        end
+      ] # Convert the whole thing to a valid Hash
+    rescue => e
+      raise "Invalid BEAKER_GEM_OPTIONS: '#{beaker_gem_options}' => '#{e}'"
+    end
+  else
+    gem 'beaker', beaker_gem_options
+  end
+
   gem 'beaker-rspec'
   gem 'beaker-windows'
   gem 'net-ssh'

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ group :system_tests do
     begin
       gem 'beaker', Hash[
         beaker_gem_options.split(',').map do |x| # Split passed options on k/v pairs
-          x.strip.split(/:\s|\s+=>\s+/) # Allow for either format hash keys
+          x.gsub('"', '').strip.split(/:\s|\s+=>\s+/) # Allow for either format hash keys
         end.map do |k,v|
           [
             k.delete(':').to_sym, # Convert all keys to symbols

--- a/lib/simp/beaker_helpers/version.rb
+++ b/lib/simp/beaker_helpers/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 module Simp::BeakerHelpers
-  VERSION = '1.18.7'
+  VERSION = '1.18.8'
 end


### PR DESCRIPTION
Added support for an environment variable BEAKER_VERSION due to the
Beaker maintenance team being willing to run our tests if they can
easily point to a different location/version for upstream beaker.