### PR TITLE
(SIMP-7816) Work around Vagrant + EL8 FIPS issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-### 1.18.4 /2020-03-31
+### 1.18.5 / 2020-06-02
+* Allow Vagrant to connect to EL8+ hosts in FIPS mode
+
+### 1.18.4 / 2020-03-31
 * Fix capturing error messages when inspec fails to generate results
 
 ### 1.18.3 / 2020-02-24

--- a/lib/simp/beaker_helpers.rb
+++ b/lib/simp/beaker_helpers.rb
@@ -327,6 +327,16 @@ module Simp::BeakerHelpers
 
       # Enable FIPS and then reboot to finish.
       on(sut, %(puppet apply --verbose #{fips_enable_modulepath} -e "class { 'fips': enabled => true }"))
+
+      # Work around Vagrant and cipher restrictions in EL8+
+      #
+      # Hopefully, Vagrant will update the used ciphers at some point but who
+      # knows when that will be
+      opensshserver_config = '/etc/crypto-policies/back-ends/opensshserver.config'
+      if file_exists_on(host, opensshserver_config)
+        on(host, "sed --follow-symlinks -i 's/PubkeyAcceptedKeyTypes=/PubkeyAcceptedKeyTypes=ssh-rsa,/' #{opensshserver_config}")
+      end
+
       sut.reboot
     end
   end

--- a/lib/simp/beaker_helpers/version.rb
+++ b/lib/simp/beaker_helpers/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 module Simp::BeakerHelpers
-  VERSION = '1.18.4'
+  VERSION = '1.18.5'
 end


### PR DESCRIPTION
* Allow Vagrant to connect to EL8+ hosts in FIPS mode

[SIMP-7816] #close

[SIMP-7816]: https://simp-project.atlassian.net/browse/SIMP-7816