### PR TITLE
(SIMP-8416) Packagecloud and rsync fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ### 1.19.0 / 2020-09-30
 * Fixed:
   * rsync handling has a better check to see if rsync actually works prior to
-  * using it.  The old method had the potential to try and use rsync even if it
-  * no longer worked (FIPS flipped for example).
+    using it.  The old method had the potential to try and use rsync even if it
+    no longer worked (FIPS flipped for example).
 * Changed:
   * Migrated from PackageCloud to the SIMP download server for updates moving
     forward.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+### 1.19.0 / 2020-09-30
+* Fixed:
+  * rsync handling has a better check to see if rsync actually works prior to
+  * using it.  The old method had the potential to try and use rsync even if it
+  * no longer worked (FIPS flipped for example).
+* Changed:
+  * Migrated from PackageCloud to the SIMP download server for updates moving
+    forward.
+
 ### 1.18.9 / 2020-08-04
 * Change windows 2012r2 VM to work around issues where the old image had
   duplicate ports trying to be opened

--- a/lib/simp/beaker_helpers.rb
+++ b/lib/simp/beaker_helpers.rb
@@ -1241,6 +1241,9 @@ done
         to_disable << 'simp-community-puppet'
       end
 
+      # NOTE: This --enablerepo enables the repos for listing and is inherited
+      # from YUM. This does not actually "enable" the repos, that would require
+      # the "--enable" option (from yum-config-manager) :-D.
       available_repos = on(sut, %{yum-config-manager --enablerepo="*"}).stdout.lines.grep(/\A\[(.+)\]\Z/){|x| $1}
 
       invalid_repos = (to_disable - available_repos)

--- a/lib/simp/beaker_helpers.rb
+++ b/lib/simp/beaker_helpers.rb
@@ -606,7 +606,7 @@ module Simp::BeakerHelpers
   end
 
   def sosreport(sut, dest='sosreports')
-    on(sut, 'puppet resource package simp-release-community source="https://download.simp-project.com/simp-release-community.rpm" ensure=latest provider=rpm')
+    on(sut, 'puppet resource package sos ensure=latest')
     on(sut, 'sosreport --batch')
 
     files = on(sut, 'ls /var/tmp/sosreport* /tmp/sosreport* 2>/dev/null', :accept_all_exit_codes => true).output.lines.map(&:strip)

--- a/lib/simp/beaker_helpers/version.rb
+++ b/lib/simp/beaker_helpers/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 module Simp::BeakerHelpers
-  VERSION = '1.18.9'
+  VERSION = '1.19.0'
 end

--- a/spec/acceptance/suites/default/install_simp_deps_repo_spec.rb
+++ b/spec/acceptance/suites/default/install_simp_deps_repo_spec.rb
@@ -2,42 +2,35 @@ require 'spec_helper_acceptance'
 
 hosts.each do |host|
   describe '#write_hieradata_to' do
+    expect_failures = false
+    if hosts_with_role(hosts, 'el8').include?(host)
+      expect_failures = true
+    end
 
     it 'should install yum utils' do
       host.install_package('yum-utils')
     end
 
-    context 'defailt settings' do
+    context 'default settings' do
       before(:all) { install_simp_repos(host) }
 
-      it 'creates the repo' do
-        on host, 'test -f /etc/yum.repos.d/simp.repo'
-        on host, 'test -f /etc/yum.repos.d/simp_deps.repo'
-      end
-
       it 'enables the correct repos' do
-        simp6info = on(host, '/usr/bin/yum repolist -v simp | grep ^Repo-status').stdout.strip
-        expect(simp6info).to match(/.*Repo-status.*enabled.*/)
-        simp6depsinfo = on(host, 'yum repolist -v simp_deps| grep ^Repo-status').stdout.strip
-        expect(simp6depsinfo).to match(/.*Repo-status.*enabled.*/)
+        skip "#{host} is not supported yet" if expect_failures
+        on(host, 'yum -y list simp')
       end
     end
 
     context 'when passed a disabled list ' do
-      before(:all) { install_simp_repos(host, ['simp'] ) }
-
-      it 'creates the repo' do
-        on host, 'test -f /etc/yum.repos.d/simp.repo'
-        on host, 'test -f /etc/yum.repos.d/simp_deps.repo'
-      end
+      before(:all) { install_simp_repos(host, ['simp-community-simp'] ) }
 
       it 'enables the correct repos' do
-        simp6info = on(host, 'yum repolist -v simp | grep ^Repo-status').stdout.strip
-        expect(simp6info).to match(/.*Repo-status.*disabled.*/)
-        simp6depsinfo = on(host, 'yum repolist -v simp_deps| grep ^Repo-status').stdout.strip
-        expect(simp6depsinfo).to match(/.*Repo-status.*enabled.*/)
+        skip "#{host} is not supported yet" if expect_failures
+        on(host, 'yum -y list postgresql96')
+      end
+
+      it 'disables the correct repos' do
+        on(host, 'yum -y list simp', :acceptable_exit_codes => [1])
       end
     end
-
   end
 end

--- a/spec/acceptance/suites/default/install_simp_deps_repo_spec.rb
+++ b/spec/acceptance/suites/default/install_simp_deps_repo_spec.rb
@@ -17,6 +17,7 @@ hosts.each do |host|
       it 'enables the correct repos' do
         skip "#{host} is not supported yet" if expect_failures
         on(host, 'yum -y list simp')
+        on(host, 'yum -y list postgresql96')
       end
     end
 


### PR DESCRIPTION
* Fixed:
  * rsync handling has a better check to see if rsync actually works prior to
    using it.  The old method had the potential to try and use rsync even if it
    no longer worked (FIPS flipped for example).
* Changed:
  * Migrated from PackageCloud to the SIMP download server for updates moving
    forward.

SIMP-8416 #comment simp-beaker-helpers update