### PR TITLE
(SIMP-8925) Use stdout instead of output in pfact_on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   * Fixed the file_content_on method
   * Removed EL 6 support from the tests since the core repos are defunct
   * Started removing some of the puppet 4 tests
+  * Fixed an issue with pfact_on
 
 ### 1.19.0 / 2020-09-30
 * Fixed:

--- a/lib/simp/beaker_helpers.rb
+++ b/lib/simp/beaker_helpers.rb
@@ -114,7 +114,7 @@ module Simp::BeakerHelpers
 
   # use the `puppet fact` face to look up facts on an SUT
   def pfact_on(sut, fact_name)
-    facts_json = on(sut,'puppet facts find xxx').output
+    facts_json = on(sut,'puppet facts find xxx').stdout
     facts      = JSON.parse(facts_json).fetch( 'values' )
     facts.fetch(fact_name)
   end


### PR DESCRIPTION
This avoids problems with JSON parsing when there is output on stderr.

SIMP-8925 #close