### PR TITLE
[WIP] (SIMP-8928) Keep BEAKER_RHSM_* values private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### 1.19.2 / 2020-12-19
 * Fixed:
+  * `rhel_rhsm_subscribe`:  Prevent exposing sensitive `BEAKER_RHSM_*` data
+    on the SUT command line by passing the data as SUT-side environment
+    variables
+
+### 1.19.2 / 2020-12-19
+* Fixed:
   * Fixed an issue with pfact_on
 
 ### 1.19.1 / 2020-12-02

--- a/lib/simp/beaker_helpers.rb
+++ b/lib/simp/beaker_helpers.rb
@@ -590,7 +590,17 @@ module Simp::BeakerHelpers
       sub_status = on(sut, 'subscription-manager status', :accept_all_exit_codes => true)
       unless sub_status.exit_code == 0
         logger.info("Registering #{sut} via subscription-manager")
-        on(sut, %{subscription-manager register --auto-attach --name='#{rhsm_opts[:system_name]}' --username='#{rhsm_opts[:username]}' --password='#{rhsm_opts[:password]}'}, :silent => true)
+        on(sut,
+          %Q[subscription-manager register --auto-attach \
+            --name='#{rhsm_opts[:system_name]}' \
+            --username="$BEAKER_RHSM_USER" \
+            --password="$BEAKER_RHSM_PASS"],
+          :environment => {
+            'BEAKER_RHSM_USER' => rhsm_opts[:username],
+            'BEAKER_RHSM_PASS' => rhsm_opts[:password],
+          },
+          :silent => true
+        )
       end
 
       if rhsm_opts[:repo_list][os_release]


### PR DESCRIPTION
This commit updates the logic of `rhel_rhsm_subscribe` to prevent
the beaker from printing the values of the `BEAKER_RHSM_*` env vars
in the rhsm subscription command line by passing them to the host as
SUT-side environment variables.

[SIMP-8928] #close

[SIMP-8928]: https://simp-project.atlassian.net/browse/SIMP-8928