### PR TITLE
(SIMP-7822) Add EPEL installer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### 1.20.0 / 2021-01-05
+* Added:
+  * A `enable_epel_on` function that follows the instructions on the EPEL
+    website to properly enable EPEL on hosts. May be disabled using
+    `BEAKER_enable_epel=no`.
+  * An Ubuntu nodeset to make sure our default settings don't destroy other
+    Linux systems.
+
 ### 1.19.4 / 2021-01-05
 * Fixed:
   * Only return a default empty string when `pfact_on` finds a `nil` value

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,13 @@
     `BEAKER_enable_epel=no`.
   * An Ubuntu nodeset to make sure our default settings don't destroy other
     Linux systems.
+  * Added has_crypto_policies method for determining if crypto policies are
+    present on the SUT
+  * Added munge_ssh_crypto_policies to allow vagrant to SSH back into systems
+    with restrictive crypto policies (usually FIPS)
 * Fixed:
   * Modify all crypto-policy backend files to support ssh-rsa keys
+  * Try harder when doing yum installations
 
 ### 1.19.4 / 2021-01-05
 * Fixed:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
     `BEAKER_enable_epel=no`.
   * An Ubuntu nodeset to make sure our default settings don't destroy other
     Linux systems.
+* Fixed:
+  * Modify all crypto-policy backend files to support ssh-rsa keys
 
 ### 1.19.4 / 2021-01-05
 * Fixed:

--- a/lib/simp/beaker_helpers.rb
+++ b/lib/simp/beaker_helpers.rb
@@ -487,7 +487,7 @@ module Simp::BeakerHelpers
 
       # This is based on the official EPEL docs https://fedoraproject.org/wiki/EPEL
       if ['RedHat', 'CentOS'].include?(os_info['name'])
-        on sut, %{puppet resource package epel-release source=https://dl.fedoraproject.org/pub/epel/epel-release-latest-#{os_maj_rel}.noarch.rpm}
+        on sut, %{yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-#{os_maj_rel}.noarch.rpm}
 
         if os_info['name'] == 'RedHat'
           if os_maj_rel == '7'

--- a/lib/simp/beaker_helpers.rb
+++ b/lib/simp/beaker_helpers.rb
@@ -381,9 +381,10 @@ module Simp::BeakerHelpers
       #
       # Hopefully, Vagrant will update the used ciphers at some point but who
       # knows when that will be
-      opensshserver_config = '/etc/crypto-policies/back-ends/opensshserver.config'
-      if file_exists_on(sut, opensshserver_config)
-        on(sut, "sed --follow-symlinks -i 's/PubkeyAcceptedKeyTypes=/PubkeyAcceptedKeyTypes=ssh-rsa,/' #{opensshserver_config}")
+      crypto_backend_path = '/etc/crypto-policies/back-ends'
+      if file_exists_on(sut, crypto_backend_path)
+        on(sut, "sed --follow-symlinks -i 's/PubkeyAcceptedKeyTypes=/PubkeyAcceptedKeyTypes=ssh-rsa,/' #{crypto_backend_path}/*")
+        on(sut, "sed --follow-symlinks -i 's/PubkeyAcceptedKeyTypes /PubkeyAcceptedKeyTypes ssh-rsa,/' #{crypto_backend_path}/*")
       end
 
       sut.reboot

--- a/lib/simp/beaker_helpers.rb
+++ b/lib/simp/beaker_helpers.rb
@@ -374,6 +374,14 @@ module Simp::BeakerHelpers
         on(sut, module_install_cmd)
       end
 
+      crypto_policies = '/etc/crypto-policies'
+      has_crypto_policies = file_exists_on(sut, "#{crypto_policies}/config")
+
+      if has_crypto_policies
+        # Needed because various versions of crypto-policies are broken
+        on(sut, "puppet resource package crypto-policies ensure=latest")
+      end
+
       # Enable FIPS and then reboot to finish.
       on(sut, %(puppet apply --verbose #{fips_enable_modulepath} -e "class { 'fips': enabled => true }"))
 
@@ -381,8 +389,7 @@ module Simp::BeakerHelpers
       #
       # Hopefully, Vagrant will update the used ciphers at some point but who
       # knows when that will be
-      crypto_policies = '/etc/crypto-policies'
-      if file_exists_on(sut, "#{crypto_policies}/config")
+      if has_crypto_policies
         on(sut, "sed --follow-symlinks -i 's/PubkeyAcceptedKeyTypes=/PubkeyAcceptedKeyTypes=ssh-rsa,/' #{crypto_policies}/back-ends/*")
         on(sut, "sed --follow-symlinks -i 's/PubkeyAcceptedKeyTypes /PubkeyAcceptedKeyTypes ssh-rsa,/' #{crypto_policies}/back-ends/*")
       end

--- a/lib/simp/beaker_helpers.rb
+++ b/lib/simp/beaker_helpers.rb
@@ -382,7 +382,7 @@ module Simp::BeakerHelpers
       # Hopefully, Vagrant will update the used ciphers at some point but who
       # knows when that will be
       crypto_backend_path = '/etc/crypto-policies/back-ends'
-      if file_exists_on(sut, crypto_backend_path)
+      if file_exists_on(sut, "#{crypto_backend_path}/config")
         on(sut, "sed --follow-symlinks -i 's/PubkeyAcceptedKeyTypes=/PubkeyAcceptedKeyTypes=ssh-rsa,/' #{crypto_backend_path}/*")
         on(sut, "sed --follow-symlinks -i 's/PubkeyAcceptedKeyTypes /PubkeyAcceptedKeyTypes ssh-rsa,/' #{crypto_backend_path}/*")
       end

--- a/lib/simp/beaker_helpers.rb
+++ b/lib/simp/beaker_helpers.rb
@@ -503,7 +503,8 @@ module Simp::BeakerHelpers
 
         if os_info['name'] == 'CentOS'
           if os_maj_rel == '8'
-            on sut, %{dnf config-manager --set-enabled powertools}
+            # 8.0 fallback
+            on sut, %{dnf config-manager --set-enabled powertools || dnf config-manager --set-enabled PowerTools}
           end
         end
       end

--- a/lib/simp/beaker_helpers.rb
+++ b/lib/simp/beaker_helpers.rb
@@ -381,10 +381,10 @@ module Simp::BeakerHelpers
       #
       # Hopefully, Vagrant will update the used ciphers at some point but who
       # knows when that will be
-      crypto_backend_path = '/etc/crypto-policies/back-ends'
-      if file_exists_on(sut, "#{crypto_backend_path}/config")
-        on(sut, "sed --follow-symlinks -i 's/PubkeyAcceptedKeyTypes=/PubkeyAcceptedKeyTypes=ssh-rsa,/' #{crypto_backend_path}/*")
-        on(sut, "sed --follow-symlinks -i 's/PubkeyAcceptedKeyTypes /PubkeyAcceptedKeyTypes ssh-rsa,/' #{crypto_backend_path}/*")
+      crypto_policies = '/etc/crypto-policies'
+      if file_exists_on(sut, "#{crypto_policies}/config")
+        on(sut, "sed --follow-symlinks -i 's/PubkeyAcceptedKeyTypes=/PubkeyAcceptedKeyTypes=ssh-rsa,/' #{crypto_policies}/back-ends/*")
+        on(sut, "sed --follow-symlinks -i 's/PubkeyAcceptedKeyTypes /PubkeyAcceptedKeyTypes ssh-rsa,/' #{crypto_policies}/back-ends/*")
       end
 
       sut.reboot

--- a/lib/simp/beaker_helpers/constants.rb
+++ b/lib/simp/beaker_helpers/constants.rb
@@ -17,7 +17,11 @@ module Simp::BeakerHelpers
     require 'open-uri'
 
     begin
-      ONLINE = true if open('http://google.com')
+      if URI.respond_to?(:open)
+        ONLINE = true if URI.open('http://google.com')
+      else
+        ONLINE = true if open('http://google.com')
+      end
     rescue
       ONLINE = false
     end

--- a/lib/simp/beaker_helpers/version.rb
+++ b/lib/simp/beaker_helpers/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 module Simp::BeakerHelpers
-  VERSION = '1.19.4'
+  VERSION = '1.20.0'
 end

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -36,3 +36,14 @@ CONFIG:
 <% if ENV['BEAKER_PUPPET_COLLECTION'] -%>
   puppet_collection: <%= ENV['BEAKER_PUPPET_COLLECTION'] %>
 <% end -%>
+  ssh:
+    keepalive: true
+    keepalive_interval: 10
+    host_key:
+      - <%= Net::SSH::Transport::Algorithms::ALGORITHMS[:host_key].join("\n#{' '*6}- ") %>
+    kex:
+      - <%= Net::SSH::Transport::Algorithms::ALGORITHMS[:kex].join("\n#{' '*6}- ") %>
+    encryption:
+      - <%= Net::SSH::Transport::Algorithms::ALGORITHMS[:encryption].join("\n#{' '*6}- ") %>
+    hmac:
+      - <%= Net::SSH::Transport::Algorithms::ALGORITHMS[:hmac].join("\n#{' '*6}- ") %>

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -21,6 +21,14 @@ HOSTS:
     box: centos/8
     hypervisor: <%= hypervisor %>
 
+  el8-0:
+    roles:
+      - el8
+    platform: el-8-x86_64
+    box: centos/8
+    box_version: "1905.1"
+    hypervisor: <%= hypervisor %>
+
 CONFIG:
   log_level: verbose
   type: aio

--- a/spec/acceptance/nodesets/ubuntu.yml
+++ b/spec/acceptance/nodesets/ubuntu.yml
@@ -6,19 +6,9 @@
   end
 -%>
 HOSTS:
-  el7:
-    roles:
-      - el7
-      - master
-    platform: el-7-x86_64
-    box: centos/7
-    hypervisor: <%= hypervisor %>
-
-  el8:
-    roles:
-      - el8
-    platform: el-8-x86_64
-    box: centos/8
+  focal:
+    platform: ubuntu-20.04-x86_64
+    box: ubuntu/focal64
     hypervisor: <%= hypervisor %>
 
 CONFIG:


### PR DESCRIPTION
* Added:
  * A `enable_epel_on` function that follows the instructions on the EPEL
    website to properly enable EPEL on hosts. May be disabled using
    `BEAKER_enable_epel=no`.
  * An Ubuntu nodeset to make sure our default settings don't destroy other
    Linux systems.

SIMP-7822 #comment added EPEL installer for consistency