### PR TITLE
Additional pfact_on fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.fips_fixtures.yml
 *.gem
 *.swp
 Gemfile.lock

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -97,6 +97,8 @@ variables:
   changes:
     - .gitlab-ci.yml
     - .fixtures.yml
+    - .rspec
+    - metadata.json
     - "spec/spec_helper.rb"
     - "spec/{classes,unit,defines,type_aliases,types,hosts}/**/*.rb"
     - "{manifests,files,types}/**/*"
@@ -106,11 +108,12 @@ variables:
     - "SIMP/**/*"
     - "data/**/*"
   exists:
-    - "spec/{classes,unit,defines,type_aliases,types,hosts}/**/*_spec.rb"
+    - "spec/{classes,unit,defines,type_aliases,types,hosts,lib}/**/*_spec.rb"
 
 .relevant_file_conditions_trigger_acceptance_tests: &relevant_file_conditions_trigger_acceptance_tests
   changes:
     - .gitlab-ci.yml
+    - .fixtures.yml
     - "spec/spec_helper_acceptance.rb"
     - "spec/acceptance/**/*"
     - "{manifests,files,types}/**/*"
@@ -286,21 +289,14 @@ variables:
 pup5-unit:
   <<: *pup_5
   <<: *unit_tests
-  <<: *with_SIMP_SPEC_MATRIX_LEVEL_2
 
 pup6-unit:
   <<: *pup_6
-  <<: *unit_tests
-  <<: *with_SIMP_SPEC_MATRIX_LEVEL_2
-
-pup6.18.0-unit:
-  <<: *pup_6_18_0
   <<: *unit_tests
 
 pup7-unit:
   <<: *pup_7
   <<: *unit_tests
-  <<: *with_SIMP_SPEC_MATRIX_LEVEL_2
 
 # ------------------------------------------------------------------------------
 #             NOTICE: **This file is maintained with puppetsync**

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -101,12 +101,9 @@ variables:
     - metadata.json
     - "spec/spec_helper.rb"
     - "spec/{classes,unit,defines,type_aliases,types,hosts}/**/*.rb"
-    - "{manifests,files,types}/**/*"
-    - "templates/*.{erb,epp}"
-    - "lib/**/*"
+    - "{SIMP,data,manifests,files,types,lib}/**/*"
+    - "templates/**/*.{erb,epp}"
     - "Gemfile"
-    - "SIMP/**/*"
-    - "data/**/*"
   exists:
     - "spec/{classes,unit,defines,type_aliases,types,hosts,lib}/**/*_spec.rb"
 
@@ -116,12 +113,9 @@ variables:
     - .fixtures.yml
     - "spec/spec_helper_acceptance.rb"
     - "spec/acceptance/**/*"
-    - "{manifests,files,types}/**/*"
-    - "templates/*.{erb,epp}"
-    - "lib/**/*"
+    - "{SIMP,data,manifests,files,types,lib}/**/*"
+    - "templates/**/*.{erb,epp}"
     - "Gemfile"
-    - "SIMP/**/*"
-    - "data/**/*"
   exists:
     - "spec/acceptance/**/*_spec.rb"
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -302,6 +302,26 @@ pup7-unit:
 # Repo-specific content
 # ==============================================================================
 
+#=======================================================================
+# Packaging test
+
+pup5-pkg:
+  <<: *pup_5
+  <<: *unit_tests
+  script:
+    'bundle exec rake pkg:gem'
+
+pup6-pkg:
+  <<: *pup_6
+  <<: *unit_tests
+  script:
+    'bundle exec rake pkg:gem'
+
+pup7-pkg:
+  <<: *pup_7
+  <<: *unit_tests
+  script:
+    'bundle exec rake pkg:gem'
 
 #=======================================================================
 # Acceptance tests

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -100,7 +100,7 @@ variables:
     - .rspec
     - metadata.json
     - "spec/spec_helper.rb"
-    - "spec/{classes,unit,defines,type_aliases,types,hosts}/**/*.rb"
+    - "spec/{classes,unit,defines,type_aliases,types,hosts,lib}/**/*.rb"
     - "{SIMP,data,manifests,files,types,lib}/**/*"
     - "templates/**/*.{erb,epp}"
     - "Gemfile"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+### 1.19.4 / 2021-01-05
+* Fixed:
+  * Only return a default empty string when `pfact_on` finds a `nil` value
+    * Added an acceptance test to validate this
+  * Ensure that we start with `facter -p` for `facter` < 4.0 and continue to
+      `puppet facts` otherwise
+  * Updated the Rakefile to skip symlinks in chmods which fixes the ability to
+    build gems
+
 ### 1.19.3 / 2021-01-01
 * Fixed:
   * Ensure that `pfact_on` can handle fact dot notation

--- a/Rakefile
+++ b/Rakefile
@@ -30,7 +30,7 @@ task :chmod do
   gemspec = File.expand_path( "#{@package}.gemspec", @rakefile_dir ).strip
   spec = Gem::Specification::load( gemspec )
   spec.files.each do |file|
-    FileUtils.chmod 'go=r', file
+    FileUtils.chmod 'go=r', file unless File.symlink?(file)
   end
 end
 

--- a/lib/simp/beaker_helpers/version.rb
+++ b/lib/simp/beaker_helpers/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 module Simp::BeakerHelpers
-  VERSION = '1.19.3'
+  VERSION = '1.19.4'
 end

--- a/spec/acceptance/suites/default/fixture_modules_spec.rb
+++ b/spec/acceptance/suites/default/fixture_modules_spec.rb
@@ -31,7 +31,7 @@ context 'after copy_fixture_modules_to( hosts )' do
   end
 
   describe "pfact_on(master,'fips_enabled')" do
-    it 'should not return "false"' do
+    it 'should return false' do
       expect(pfact_on(master, 'fips_enabled')).to eq false
     end
   end

--- a/spec/acceptance/suites/default/fixture_modules_spec.rb
+++ b/spec/acceptance/suites/default/fixture_modules_spec.rb
@@ -29,4 +29,10 @@ context 'after copy_fixture_modules_to( hosts )' do
       expect(pfact_on(master, 'os.release.foo')).to eq ''
     end
   end
+
+  describe "pfact_on(master,'fips_enabled')" do
+    it 'should not return "false"' do
+      expect(pfact_on(master, 'fips_enabled')).to eq false
+    end
+  end
 end

--- a/spec/acceptance/suites/default/fixture_modules_spec.rb
+++ b/spec/acceptance/suites/default/fixture_modules_spec.rb
@@ -31,8 +31,10 @@ context 'after copy_fixture_modules_to( hosts )' do
   end
 
   describe "pfact_on(master,'fips_enabled')" do
+    expected = (ENV['BEAKER_fips'] == 'yes')
+
     it 'should return false' do
-      expect(pfact_on(master, 'fips_enabled')).to eq false
+      expect(pfact_on(master, 'fips_enabled')).to eq expected
     end
   end
 end

--- a/spec/lib/simp/beaker_helpers_spec.rb
+++ b/spec/lib/simp/beaker_helpers_spec.rb
@@ -103,7 +103,19 @@ describe 'Simp::BeakerHelpers' do
     end
 
     it 'uses defaults when no environment variables are set' do
-      expect( @helper.get_puppet_install_info[:puppet_install_version] ).to match(/^6\./)
+
+      # Prevent namespace pollution
+      pipe_out,pipe_in = IO.pipe
+      fork do
+        pipe_out.close
+        require 'puppet'
+        pipe_in.write(Puppet.version)
+      end
+      pipe_in.close
+
+      expected_version = pipe_out.gets
+
+      expect( @helper.get_puppet_install_info[:puppet_install_version] ).to match(expected_version)
       expect( @helper.get_puppet_install_info[:puppet_collection] ).to eq('puppet6')
       expect( @helper.get_puppet_install_info[:puppet_install_type] ).to eq('agent')
     end

--- a/spec/lib/simp/beaker_helpers_spec.rb
+++ b/spec/lib/simp/beaker_helpers_spec.rb
@@ -114,9 +114,10 @@ describe 'Simp::BeakerHelpers' do
       pipe_in.close
 
       expected_version = pipe_out.gets
+      expected_major_version = expected_version.split('.').first
 
       expect( @helper.get_puppet_install_info[:puppet_install_version] ).to match(expected_version)
-      expect( @helper.get_puppet_install_info[:puppet_collection] ).to eq('puppet6')
+      expect( @helper.get_puppet_install_info[:puppet_collection] ).to eq("puppet#{expected_major_version}")
       expect( @helper.get_puppet_install_info[:puppet_install_type] ).to eq('agent')
     end
 


### PR DESCRIPTION
* Fixed:
  * Only return a default empty string when `pfact_on` finds a `nil` value
    * Added an acceptance test to validate this
  * Ensure that we start with `facter -p` for `facter` < 4.0 and continue to
      `puppet facts` otherwise
  * Updated the Rakefile to skip symlinks in chmods which fixes the ability to
    build gems