### PR TITLE
(SIMP-7822) Add EPEL installer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 1.20.1 / 2021-01-08
+* Fixed:
+  * Ensure that yum calls commands appropriately depending on whether or not
+    packages are already installed.
+  * Also change all HostKeyAlgorithms settings for SSH connections
+
 ### 1.20.0 / 2021-01-05
 * Added:
   * A `enable_epel_on` function that follows the instructions on the EPEL

--- a/lib/simp/beaker_helpers/version.rb
+++ b/lib/simp/beaker_helpers/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 module Simp::BeakerHelpers
-  VERSION = '1.20.0'
+  VERSION = '1.20.1'
 end


### PR DESCRIPTION
* Added:
  * A `enable_epel_on` function that follows the instructions on the EPEL
    website to properly enable EPEL on hosts. May be disabled using
    `BEAKER_enable_epel=no`.
  * An Ubuntu nodeset to make sure our default settings don't destroy other
    Linux systems.
* Fixed:
  * Workaround URI.open change in Ruby 3

SIMP-7822 #comment added EPEL installer for consistency