### PR TITLE
(SIMP-9114) Mitigate FIPS issues in CentOS 8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+### 1.21.1 / 2021-01-13
+* Added:
+  * update_package_from_centos_stream method
+  * install_latest_package_on method
+* Fixed:
+  * Removed some of the extraneous calls to facter
+  * Automatically pull the CentOS 8 kernel to the latest version in
+    CentOS-Stream to work around issues on FIPS systems
+
 ### 1.20.1 / 2021-01-08
 * Fixed:
   * Ensure that yum calls commands appropriately depending on whether or not

--- a/lib/simp/beaker_helpers.rb
+++ b/lib/simp/beaker_helpers.rb
@@ -1339,7 +1339,7 @@ module Simp::BeakerHelpers
     install_latest_package_on(sut, 'yum-utils')
     install_latest_package_on(
       sut,
-      'yum-utils',
+      'simp-release-community',
       "https://download.simp-project.com/simp-release-community.rpm",
     )
 

--- a/lib/simp/beaker_helpers/version.rb
+++ b/lib/simp/beaker_helpers/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 module Simp::BeakerHelpers
-  VERSION = '1.20.1'
+  VERSION = '1.21.0'
 end


### PR DESCRIPTION
* Added:
  * update_package_from_centos_stream method
  * install_latest_package_on method
* Fixed:
  * Removed some of the extraneous calls to facter
  * Automatically pull the CentOS 8 kernel to the latest version in
    CentOS-Stream to work around issues on FIPS systems

[SIMP-9114] #comment Update beaker helpers to work around FIPS issue

[SIMP-9114]: https://simp-project.atlassian.net/browse/SIMP-9114