### PR TITLE
(SIMP-MAINT) Bump version for mismatched version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.21.2 / 2021-01-15
+* Fixed version mismatch.  1.21.1 was tagged with an incorrect version
+  in version.rb.
+
 ### 1.21.1 / 2021-01-13
 * Added:
   * update_package_from_centos_stream method

--- a/lib/simp/beaker_helpers/version.rb
+++ b/lib/simp/beaker_helpers/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 module Simp::BeakerHelpers
-  VERSION = '1.21.0'
+  VERSION = '1.21.2'
 end


### PR DESCRIPTION
* Fixed version mismatch.  1.21.1 was tagged with an incorrect version
  in version.rb.