### PR TITLE
(SIMP-MAINT) Remove use of OpenStruct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 1.21.4 / 2021-01-21
+* Fixed:
+  * Reverted the use of OpenStruct due to issues with seralization
+  * Hash objects have a 'dig' method as of Ruby 2.3 so pinned this gem to a
+    minimum version of Ruby 2.3
+
 ### 1.21.3 / 2021-01-20
 * Fixed:
   * Allow all methods that can safely take SUT arrays to do so

--- a/lib/simp/beaker_helpers.rb
+++ b/lib/simp/beaker_helpers.rb
@@ -166,8 +166,6 @@ module Simp::BeakerHelpers
 
   # use the `puppet fact` face to look up facts on an SUT
   def pfact_on(sut, fact_name)
-    require 'ostruct'
-
     found_fact = nil
     # If puppet is not installed, there are no puppet facts to fetch
     if sut.which('puppet').empty?
@@ -176,16 +174,15 @@ module Simp::BeakerHelpers
       facts_json = nil
       begin
         cmd_output = on(sut, 'facter -p --json', :silent => true)
-
         # Facter 4+
         raise('skip facter -p') if (cmd_output.stderr =~ /no longer supported/)
 
-        facts = JSON.parse(cmd_output.stdout, object_class: OpenStruct)
+        facts = JSON.parse(cmd_output.stdout)
       rescue StandardError
         # If *anything* fails, we need to fall back to `puppet facts`
 
         facts_json = on(sut, 'puppet facts find garbage_xxx', :silent => true).stdout
-        facts = JSON.parse(facts_json, object_class: OpenStruct).values
+        facts = JSON.parse(facts_json)['values']
       end
 
       found_fact = facts.dig(*(fact_name.split('.')))

--- a/lib/simp/beaker_helpers/version.rb
+++ b/lib/simp/beaker_helpers/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 module Simp::BeakerHelpers
-  VERSION = '1.21.3'
+  VERSION = '1.21.4'
 end

--- a/simp-beaker-helpers.gemspec
+++ b/simp-beaker-helpers.gemspec
@@ -18,6 +18,9 @@ Gem::Specification.new do |s|
   s.metadata = {
                  'issue_tracker' => 'https://simp-project.atlassian.net'
                }
+
+  s.required_ruby_version = '>= 2.3.0'
+
   s.add_runtime_dependency 'beaker'                      , ['>= 4.17.0', '< 5.0.0']
   s.add_runtime_dependency 'beaker-rspec'                , '~> 6.2'
   s.add_runtime_dependency 'beaker-puppet'               , ['>= 1.18.14', '< 2.0.0']


### PR DESCRIPTION
* Fixed:
  * Reverted the use of OpenStruct due to issues with seralization
  * Hash objects have a 'dig' method as of Ruby 2.3 so pinned this gem to a
    minimum version of Ruby 2.3