### PR TITLE
(SIMP-9148) Allow users to set SIMP repo release

### DIFF
--- a/.fips_fixtures
+++ b/.fips_fixtures
@@ -1,6 +1,7 @@
 ---
 fixtures:
   repositories:
+    crypto_policy: https://github.com/simp/pupmod-simp-crypto_policy
     fips: https://github.com/simp/pupmod-simp-fips
     augeasproviders_core: https://github.com/simp/augeasproviders_core
     augeasproviders_grub: https://github.com/simp/augeasproviders_grub

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+### 1.22.0 / 2021-01-27
+* Fixed:
+  * Ensure that the simp-crypto_policy module is installed when flipping to FIPS
+    mode
+  * Only attempt to install the simp repos once in case they are broken for some
+    reason
+* Added:
+  * Documentation for all of the beaker environment variables
+  * set_simp_repo_release() for setting the release and release_type of the
+    public SIMP yum repos
+  * set_yum_opts_on() method for setting bulk yum config options
+  * set_yum_opt_on() method for setting singular yum config options
+  * install_package_unless_present_on() method
+  * Allow users to set repos to disable using an environment variable
+  * A total run time summary for beaker suites
+
 ### 1.21.4 / 2021-01-21
 * Fixed:
   * Reverted the use of OpenStruct due to issues with seralization

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ sensitive).
 * BEAKER_RHSM_PASS [String]
   * The password for using with RHSM
 
-* BEAEKR_fips [yes|no]
+* BEAKER_fips [yes|no]
   * `yes` => Enable FIPS on the SUT
   * `no` => Do not manage FIPS on the SUT (will not disable if enabled)
 
@@ -464,7 +464,7 @@ might try to install packages before subscription manager is configured.
 The version of InSpec to use when running inspec tests. Currently hard-coded to
 `4.16.14` due to a bug introduced in `4.16.15`.
 
-Let to 'latest' to use the latest available in the upstream repos.
+Set to 'latest' to use the latest available in the upstream repos.
 
 ## Examples
 
@@ -568,7 +568,7 @@ underlying OS configuration.
 
 `Simp::BeakerHelpers::Snapshot.save(sut, '<name of snapshot>')` will save a
 snapshot with the given name. If the snapshot already exists, it will be
-forceably overwritten.
+forcibly overwritten.
 
 
 ##### Base Snapshots

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Methods to assist beaker acceptance tests for SIMP.
   * [`rake beaker:suites`](#rake-beakersuites)
   * [Suite Execution](#suite-execution)
     * [Environment Variables](#environment-variables)
+      * [Beaker Management](#beaker-management)
+      * [Beaker Helpers Adjustments](#beaker-helpers-adjustments)
     * [Global Suite Configuration](#global-suite-configuration)
       * [Supported Config:](#supported-config)
     * [Individual Suite Configuration](#individual-suite-configuration)
@@ -112,12 +114,68 @@ sensitive).
 
 #### Environment Variables
 
-* BEAKER_suite_runall
+##### Beaker Management
+
+* BEAKER_suite_runall [yes|no]
   * Run all Suites
 
-* BEAKER_suite_basedir
+* BEAKER_suite_basedir [String]
   * The base directory where suites will be defined
-  * Default: spec/acceptance
+  * Default: `spec/acceptance`
+
+##### Beaker Helpers Adjustments
+
+* BEAKER_SIMP_parallel [yes|no]
+  * `yes` => Run simp-beaker-helpers methods on SUTs in parallel if possible
+  * `no` => Do not run methods in parallel
+
+* BEAKER_docker_cmd [String]
+  * The specific command to use for performing `docker` operations
+
+* BEAKER_helpers_verbose [yes|no]
+  * `yes` => Enable verbose output
+  * `no` => Do not enable verbose output
+
+* BEAKER_copy_fixtures [yes|no]
+  * `yes` => Enable copying fixtures to the SUT
+  * `no` => Disable copying fixtures to the SUT
+
+* BEAKER_use_fixtures_dir_for_modules [yes|no]
+  * `yes` => Pull fixtures directly from `spec/fixtures/modules`
+  * `no` => Ignore `spec/fixtures/modules` content
+
+* BEAKER_stringify_facts [yes|no]
+  * `yes` => Enable fact stringification
+
+* BEAKER_fips_module_version [String]
+  * The specific version of the FIPS module to install from the puppet forge
+
+* BEAKER_RHSM_USER [String]
+  * The username for using with RHSM
+
+* BEAKER_RHSM_PASS [String]
+  * The password for using with RHSM
+
+* BEAEKR_fips [yes|no]
+  * `yes` => Enable FIPS on the SUT
+  * `no` => Do not manage FIPS on the SUT (will not disable if enabled)
+
+* BEAKER_no_fix_interfaces [Boolean]
+  * If present, will not try to fix the interfaces on the SUT
+
+* BEAKER_SIMP_install_repos [yes|no]
+  * `yes` => Install the SIMP YUM repositories
+  * `no` => No not install the SIMP YUM repositories
+
+* BEAKER_SIMP_disable_repos [String]
+  * Comma delimited list of YUM repositories to disable on the SUT
+
+* BEAKER_SIMP_repo_release [String]
+  * The release of SIMP to target in the YUM repos (usually a number)
+
+* BEAKER_SIMP_repo_release_type [String]
+  * The release type of SIMP to target in the YUM repos
+    * Something like `stable`, `rolling`, or `unstable`
 
 #### Global Suite Configuration
 

--- a/lib/simp/beaker_helpers/version.rb
+++ b/lib/simp/beaker_helpers/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 module Simp::BeakerHelpers
-  VERSION = '1.21.4'
+  VERSION = '1.22.0'
 end

--- a/lib/simp/rake/beaker.rb
+++ b/lib/simp/rake/beaker.rb
@@ -196,6 +196,7 @@ module Simp::Rake
           default_suite = ordered_suites.delete('default')
           ordered_suites.unshift(default_suite) if default_suite
 
+          suite_start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
           ordered_suites.each do |ste|
 
             next unless (suites[ste]['default_run'] == true)
@@ -255,6 +256,11 @@ module Simp::Rake
               $stdout.puts("\n\n=== Suite '#{name}' Complete ===\n\n")
             end
           end
+          suite_end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+          suite_run_time = ((suite_end_time - suite_start_time)/60).round(2)
+
+          $stdout.puts("== Total Runtime: #{suite_run_time} minutes ==\n\n")
 
           unless failures.keys.empty?
             $stdout.puts("The following tests had failures:")

--- a/spec/acceptance/suites/default/install_simp_deps_repo_spec.rb
+++ b/spec/acceptance/suites/default/install_simp_deps_repo_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper_acceptance'
 
 hosts.each do |host|
-  describe '#write_hieradata_to' do
-    expect_failures = false
-    if hosts_with_role(hosts, 'el8').include?(host)
-      expect_failures = true
-    end
+  expect_failures = false
+  if hosts_with_role(hosts, 'el8').include?(host)
+    expect_failures = true
+  end
 
+  describe '#install_simp_repos' do
     it 'should install yum utils' do
       host.install_package('yum-utils')
     end
@@ -18,6 +18,18 @@ hosts.each do |host|
         skip "#{host} is not supported yet" if expect_failures
         on(host, 'yum -y list simp')
         on(host, 'yum -y list postgresql96')
+      end
+    end
+
+    context 'when targeting a release type' do
+      it 'adjusts the SIMP release target' do
+        set_simp_repo_release(host, 'rolling')
+        expect(file_content_on(host, '/etc/yum/vars/simpreleasetype').strip).to eq('rolling')
+      end
+
+      it 'lists the simp rpm' do
+        skip "#{host} is not supported yet" if expect_failures
+        on(host, 'yum list simp')
       end
     end
 

--- a/spec/acceptance/suites/fips_from_fixtures/00_default_spec.rb
+++ b/spec/acceptance/suites/fips_from_fixtures/00_default_spec.rb
@@ -18,6 +18,7 @@ new_fixtures = {
   }
 }
 
+new_fixtures['fixtures']['repositories']['crypto_policy'] = 'https://github.com/simp/pupmod-simp-crypto_policy'
 new_fixtures['fixtures']['repositories']['fips'] = 'https://github.com/simp/pupmod-simp-fips'
 new_fixtures['fixtures']['repositories']['augeasproviders_core'] = 'https://github.com/simp/augeasproviders_core'
 new_fixtures['fixtures']['repositories']['augeasproviders_grub'] = 'https://github.com/simp/augeasproviders_grub'


### PR DESCRIPTION
* Fixed:
  * Ensure that the simp-crypto_policy module is installed when flipping to FIPS
    mode
  * Only attempt to install the simp repos once in case they are broken for some
    reason
* Added:
  * Documentation for all of the beaker environment variables
  * set_simp_repo_release() for setting the release and release_type of the
    public SIMP yum repos
  * set_yum_opts_on() method for setting bulk yum config options
  * set_yum_opt_on() method for setting singular yum config options
  * install_package_unless_present_on() method
  * Allow users to set repos to disable using an environment variable
  * A total run time summary for beaker suites

[SIMP-9148] #close

[SIMP-9148]: https://simp-project.atlassian.net/browse/SIMP-9148