### PR TITLE
(SIMP-8932) Enable EPEL for OEL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.22.1 / 2021-03-01
+* Fixed: enable_epel_on() now installs the correct EPEL repository
+  package on OracleLinux
+
 ### 1.22.0 / 2021-01-27
 * Fixed:
   * Ensure that the simp-crypto_policy module is installed when flipping to FIPS

--- a/lib/simp/beaker_helpers.rb
+++ b/lib/simp/beaker_helpers.rb
@@ -619,7 +619,8 @@ module Simp::BeakerHelpers
         os_maj_rel = os_info['release']['major']
 
         # This is based on the official EPEL docs https://fedoraproject.org/wiki/EPEL
-        if ['RedHat', 'CentOS'].include?(os_info['name'])
+        case os_info['name']
+        when 'RedHat','CentOS'
           install_latest_package_on(
             sut,
             'epel-release',
@@ -645,7 +646,11 @@ module Simp::BeakerHelpers
               on sut, %{dnf config-manager --set-enabled powertools || dnf config-manager --set-enabled PowerTools}
             end
           end
+        when 'OracleLinux'
+          package_name = "oracle-epel-release-el#{os_maj_rel}"
+          install_latest_package_on(sut,package_name)
         end
+
       end
     end
   end

--- a/lib/simp/beaker_helpers/version.rb
+++ b/lib/simp/beaker_helpers/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 module Simp::BeakerHelpers
-  VERSION = '1.22.0'
+  VERSION = '1.22.1'
 end


### PR DESCRIPTION
- Test for OEL are failing because nothing is done when epel repo
   is enable on OracleLinux.
- OEL has  an oracle-epel-release-<version> rpm.   This fix adds installing
  this repo when enable_epel is called in an acceptence test running on
  OEL.

SIMP-8932 #comment This fix is needed for the OEL acceptance tests in pupmod-simp-ssh