### PR TITLE
(SIMP-MAINT) Podman support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 1.23.0 / 2021-03-04
+* For `podman` support:
+  * Bumped the required beaker-docker to between 0.8.3 and 2.0.0
+  * Added a dependency on docker-api between 2.1.0 and 3.0.0
+
 ### 1.22.1 / 2021-03-01
 * Fixed: enable_epel_on() now installs the correct EPEL repository
   package on OracleLinux

--- a/simp-beaker-helpers.gemspec
+++ b/simp-beaker-helpers.gemspec
@@ -24,7 +24,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'beaker'                      , ['>= 4.17.0', '< 5.0.0']
   s.add_runtime_dependency 'beaker-rspec'                , '~> 6.2'
   s.add_runtime_dependency 'beaker-puppet'               , ['>= 1.18.14', '< 2.0.0']
-  s.add_runtime_dependency 'beaker-docker'               , '~> 0.3'
+  s.add_runtime_dependency 'beaker-docker'               , ['>= 0.8.3', '< 2.0.0']
+  s.add_runtime_dependency 'docker-api'                  , ['>= 2.1.0', '< 3.0.0']
   s.add_runtime_dependency 'beaker-vagrant'              , ['>= 0.6.4', '< 2.0.0']
   s.add_runtime_dependency 'beaker-puppet_install_helper', '~> 0.9'
   s.add_runtime_dependency 'highline'                    , '~> 2.0'


### PR DESCRIPTION
* For `podman` support:
  * Bumped the required beaker-docker to between 0.8.3 and 2.0.0
  * Added a dependency on docker-api between 2.1.0 and 3.0.0