### PR TITLE
(SIMP-MAINT) Fail suite when invalid specified nodeset

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -312,6 +312,18 @@ pup7.x-pkg:
 
 #=======================================================================
 # Acceptance tests
+
+# Verify a suite fails when an explicitly-specified nodeset does not exist.
+# It is significantly quicker to test here (where rvm is already installed
+# and the bundle is configured with this version of simp-beaker-helpers)
+# than in an acceptance test with a build user.
+default-bad-nodeset:
+  <<: *pup_6_x
+  <<: *acceptance_base
+  script:
+    - 'RESULT=`bundle exec rake beaker:suites[default,oops] 1>/dev/null; echo $?`; (test $RESULT == "1")'
+    - echo 'beaker:suites correctly failed with unknown nodeset'
+
 default:
   <<: *pup_6_x
   <<: *acceptance_base

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 1.23.2 / 2021-05-28
+* Fixed:
+  * Fail an acceptance test when an explicitly-specified nodeset for an
+    acceptance test suite does not exist and the suite is configured
+    to fail fast (default behavior).
+
 ### 1.23.1 / 2021-05-19
 * Fixed:
   * The SSG default branch is now the latest numeric tag instead of the one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 1.23.2 / 2021-05-28
+### 1.23.2 / 2021-05-29
 * Fixed:
   * Fail an acceptance test when an explicitly-specified nodeset for an
     acceptance test suite does not exist and the suite is configured

--- a/lib/simp/beaker_helpers/version.rb
+++ b/lib/simp/beaker_helpers/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 module Simp::BeakerHelpers
-  VERSION = '1.23.1'
+  VERSION = '1.23.2'
 end

--- a/lib/simp/rake/beaker.rb
+++ b/lib/simp/rake/beaker.rb
@@ -226,8 +226,14 @@ module Simp::Rake
 
             nodesets.each do |nodeset_yml|
               unless File.file?(nodeset_yml)
-                $stdout.puts("=== Suite #{name} Nodeset '#{File.basename(nodeset_yml, '.yml')}' Not Found, Skipping ===")
-                next
+                # Get here if user has specified a non-existent nodeset or the
+                # implied `default` nodeset does not exist.
+                if suite_config['fail_fast']
+                  fail("*** Suite #{name} Nodeset '#{File.basename(nodeset_yml, '.yml')}' Not Found ***")
+                else
+                  $stdout.puts("=== Suite #{name} Nodeset '#{File.basename(nodeset_yml, '.yml')}' Not Found, Skipping ===")
+                  next
+                end
               end
 
               ENV['BEAKER_setfile'] = nodeset_yml


### PR DESCRIPTION
- Fail an acceptance test when an explicitly-specified nodeset for an
  acceptance test suite does not exist and the suite is configured
  to fail fast (default behavior).
- Added an acceptance test job in the .gitlab-ci.yml to test this
  in lieu of a separate acceptance test using a build user with a
  fully-configured rvm environment.