### PR TITLE
(SIMP-10450) GHA: Update ubuntu-16.04 to latest

### DIFF
--- a/.github/workflows/pr_glci.yml
+++ b/.github/workflows/pr_glci.yml
@@ -63,7 +63,7 @@ jobs:
   # we restrict ourselves to sending data elsewhere.
   glci-syntax:
     name: '.gitlab-ci.yml Syntax'
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     outputs:
       valid: ${{ steps.validate-glci-file.outputs.valid }}
     steps:
@@ -174,7 +174,7 @@ jobs:
 ###  examine_contexts:
 ###    name: 'Examine Context contents'
 ###    if: always()
-###    runs-on: ubuntu-16.04
+###    runs-on: ubuntu-latest
 ###    needs: [ glci-syntax, contributor-permissions ]
 ###    steps:
 ###      - name: Dump contexts

--- a/.github/workflows/pr_glci_cleanup.yml
+++ b/.github/workflows/pr_glci_cleanup.yml
@@ -93,7 +93,7 @@ jobs:
 ###  examine_contexts:
 ###    name: 'Examine Context contents'
 ###    if: always()
-###    runs-on: ubuntu-16.04
+###    runs-on: ubuntu-latest
 ###    steps:
 ###      - name: Dump contexts
 ###        env:

--- a/.github/workflows/tag_deploy_rubygem.yml
+++ b/.github/workflows/tag_deploy_rubygem.yml
@@ -1,4 +1,4 @@
-# Build & Deploy RubyGem & GitHub release when a SemVer tag is pushed
+# When SemVer tag is pushed: create GitHub release & publish gem to rubygems.org
 #
 # This workflow's jobs are only triggered in repos under the `simp` organization
 # ------------------------------------------------------------------------------

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -273,10 +273,6 @@ variables:
 # Unit Tests
 #-----------------------------------------------------------------------
 
-pup5.x-unit:
-  <<: *pup_5_x
-  <<: *unit_tests
-
 pup6.x-unit:
   <<: *pup_6_x
   <<: *unit_tests
@@ -291,12 +287,6 @@ pup7.x-unit:
 
 #=======================================================================
 # Packaging test
-
-pup5.x-pkg:
-  <<: *pup_5_x
-  <<: *unit_tests
-  script:
-    'bundle exec rake pkg:gem'
 
 pup6.x-pkg:
   <<: *pup_6_x


### PR DESCRIPTION
GitHub actions' Ubuntu 16.04 environment will be removed on Sept 20,
2021.  This patch migrates all workflow using the `ubuntu-16.04`
environment to `ubuntu-latest`.

The patch enforces a standardized asset baseline using simp/puppetsync,
and may apply other updates to ensure conformity.
[SIMP-10541] #close
[SIMP-10450] #comment Add `release_rpms` to rubygem-simp-beaker-helpers

[SIMP-10541]: https://simp-project.atlassian.net/browse/SIMP-10541
[SIMP-10450]: https://simp-project.atlassian.net/browse/SIMP-10450