### PR TITLE
Prevent `spec/` directory symlink recursion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-### 1.24.2 / 2022-02-20
+### 1.24.2 / 2022-03-09
 * Fixed:
+  * Prevent `spec/` directory symlink recursion in `copy_fixture_modules_to`
   * Update the derivatives workaround to insert an inert line instead of
     commenting out the previous line to allow for logic updates
   * Addressed a bug where passing an empty exceptions array would produce an

--- a/lib/simp/beaker_helpers.rb
+++ b/lib/simp/beaker_helpers.rb
@@ -411,7 +411,7 @@ module Simp::BeakerHelpers
               begin
                 tarfile = "#{Simp::BeakerHelpers.tmpname}.tar"
 
-                excludes = PUPPET_MODULE_INSTALL_IGNORE.map do |x|
+                excludes = (PUPPET_MODULE_INSTALL_IGNORE + ['spec']).map do |x|
                   x = "--exclude '*/#{x}'"
                 end.join(' ')
 


### PR DESCRIPTION
Prevent `spec/` directory symlink recursion

Before this patch, the `tar` operation in `copy_fixture_modules_to`
could get stuck on an endless recursive directory loop when the
`spec/fixtures/modules/` directory contained a symlink to the module
itself.

The `spec/` directory is only used for spec testing and is not
required by SUTs to compile the module's code and data.

This patch prevents tar from recursing module fixtures entirely by
adding `spec/` to the directories that `tar` excludes.

Fixes #173
