### PR TITLE
Allow for sequential nodesets

### DIFF
--- a/lib/simp/rake/beaker.rb
+++ b/lib/simp/rake/beaker.rb
@@ -230,7 +230,9 @@ module Simp::Rake
             nodesets.each do |nodeset_yml|
               parsed_nodeset = ::Beaker::Options::HostsFileParser.parse_hosts_file(nodeset_yml)
 
-              if parsed_nodeset[:sequential]
+              if parsed_nodeset[:multi_node]
+                refined_nodesets.push(nodeset_yml)
+              else
                 parsed_nodeset_hosts = parsed_nodeset.delete(:HOSTS)
 
                 parsed_nodeset_hosts.each do |k,v|
@@ -256,8 +258,6 @@ module Simp::Rake
                     end
                   end
                 end
-              else
-                refined_nodesets.push(nodeset_yml)
               end
             end
 

--- a/lib/simp/rake/beaker.rb
+++ b/lib/simp/rake/beaker.rb
@@ -225,7 +225,43 @@ module Simp::Rake
               nodesets << File.join(nodeset_path, 'default.yml')
             end
 
+            refined_nodesets = []
+
             nodesets.each do |nodeset_yml|
+              parsed_nodeset = ::Beaker::Options::HostsFileParser.parse_hosts_file(nodeset_yml)
+
+              if parsed_nodeset[:sequential]
+                parsed_nodeset_hosts = parsed_nodeset.delete(:HOSTS)
+
+                parsed_nodeset_hosts.each do |k,v|
+
+                  v[:roles] ||= []
+                  v[:roles] |= ['default', 'master']
+
+                  tmp_nodeset = {
+                    :HOSTS  => { k => v },
+                    :CONFIG => parsed_nodeset
+                  }
+
+                  tmp_nodeset_file = Tempfile.new("beaker_nodeset_#{k}")
+                  tmp_nodeset_file.write(tmp_nodeset.to_yaml)
+                  tmp_nodeset_file.close
+
+                  refined_nodesets.push(tmp_nodeset_file.path)
+
+                  at_exit do
+                    if tmp_nodeset_file && File.exist?(tmp_nodeset_file.path)
+                      tmp_nodeset_file.close
+                      tmp_nodeset_file.unlink
+                    end
+                  end
+                end
+              else
+                refined_nodesets.push(nodeset_yml)
+              end
+            end
+
+            refined_nodesets.each do |nodeset_yml|
               unless File.file?(nodeset_yml)
                 # Get here if user has specified a non-existent nodeset or the
                 # implied `default` nodeset does not exist.

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -22,6 +22,7 @@ HOSTS:
     hypervisor: <%= hypervisor %>
 
 CONFIG:
+  sequential: true
   log_level: verbose
   type: aio
   vagrant_cpus: 2

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -22,7 +22,7 @@ HOSTS:
     hypervisor: <%= hypervisor %>
 
 CONFIG:
-  sequential: true
+  multi_node: <%= ['yes','true'].include?(ENV['BEAKER_multi_node']) ? true : false %>
   log_level: verbose
   type: aio
   vagrant_cpus: 2


### PR DESCRIPTION
In most modules, we wish to test multiple default nodes but generally
are are not doing multi-node testing.

Instead of using convoluted generators or additional abstract
configuration files, this allows you to simply add `sequential: true` to
the `CONFIG:` section and each host will be broken out into its own
nodeset on the fly and executed.

A future extension of this may allow for tagged clusters to run as
multi-node tests without needing additional files or settings.
