### PR TITLE
Multi_node Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 1.26.1 / 2022-06-24
+* Fixed:
+  * Ensure that `multi_node` is enabled by default for backwards compatibility
+  * Sort the discovered nodesets by default when running with `ALL` nodesets
+
 ### 1.26.0 / 2022-06-24
 * Added:
   * Allow for sequential nodesets by setting `multi_node: false` in the

--- a/lib/simp/beaker_helpers/version.rb
+++ b/lib/simp/beaker_helpers/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 module Simp::BeakerHelpers
-  VERSION = '1.26.0'
+  VERSION = '1.26.1'
 end

--- a/spec/acceptance/nodesets/amzn2.yml
+++ b/spec/acceptance/nodesets/amzn2.yml
@@ -8,7 +8,6 @@
 HOSTS:
   amzn2:
     roles:
-      - master
       - default
     platform: el-7-x86_64
     box: gbailey/amzn2

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -8,6 +8,7 @@
 HOSTS:
   el7:
     roles:
+      - default
       - el7
     platform: el-7-x86_64
     box: centos/7

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -9,7 +9,6 @@ HOSTS:
   el7:
     roles:
       - el7
-      - master
     platform: el-7-x86_64
     box: centos/7
     hypervisor: <%= hypervisor %>

--- a/spec/acceptance/nodesets/docker.yml
+++ b/spec/acceptance/nodesets/docker.yml
@@ -1,6 +1,7 @@
 HOSTS:
   el7.test.net:
     roles:
+      - default
       - el7
     platform:   el-7-x86_64
     hypervisor: docker

--- a/spec/acceptance/nodesets/docker.yml
+++ b/spec/acceptance/nodesets/docker.yml
@@ -2,7 +2,6 @@ HOSTS:
   el7.test.net:
     roles:
       - el7
-      - master
     platform:   el-7-x86_64
     hypervisor: docker
     image: simpproject/simp_beaker_el7

--- a/spec/acceptance/nodesets/oel.yml
+++ b/spec/acceptance/nodesets/oel.yml
@@ -9,7 +9,6 @@ HOSTS:
   oel7:
     roles:
       - el7
-      - master
     platform: el-7-x86_64
     box: generic/oracle7
     hypervisor: <%= hypervisor %>

--- a/spec/acceptance/nodesets/oel.yml
+++ b/spec/acceptance/nodesets/oel.yml
@@ -8,6 +8,7 @@
 HOSTS:
   oel7:
     roles:
+      - default
       - el7
     platform: el-7-x86_64
     box: generic/oracle7

--- a/spec/acceptance/nodesets/ubuntu.yml
+++ b/spec/acceptance/nodesets/ubuntu.yml
@@ -7,6 +7,8 @@
 -%>
 HOSTS:
   focal:
+    roles:
+      - default
     platform: ubuntu-20.04-x86_64
     box: ubuntu/focal64
     hypervisor: <%= hypervisor %>

--- a/spec/acceptance/suites/default/fixture_modules_spec.rb
+++ b/spec/acceptance/suites/default/fixture_modules_spec.rb
@@ -6,41 +6,41 @@ context 'after copy_fixture_modules_to( hosts )' do
     copy_fixture_modules_to( hosts )
   end
 
-  describe "fact_on(master,'root_home')" do
+  describe "fact_on(default,'root_home')" do
     it 'should not return value of `root_home`' do
-      expect(fact_on(master, 'root_home')).to eq ''
+      expect(fact_on(default, 'root_home')).to eq ''
     end
   end
 
-  describe "pfact_on(master,'root_home')" do
+  describe "pfact_on(default,'root_home')" do
     it 'should return value of `root_home`' do
-      expect(pfact_on(master, 'root_home')).to eq '/root'
+      expect(pfact_on(default, 'root_home')).to eq '/root'
     end
   end
 
-  describe "pfact_on(master,'os.release.major')" do
+  describe "pfact_on(default,'os.release.major')" do
     it 'should return the value of `os.release.major`' do
-      expect(pfact_on(master, 'os.release.major')).to match(/.+/)
+      expect(pfact_on(default, 'os.release.major')).to match(/.+/)
     end
   end
 
-  describe "pfact_on(master,'os.release.foo')" do
+  describe "pfact_on(default,'os.release.foo')" do
     it 'should not return the value of `os.release.foo`' do
-      expect(pfact_on(master, 'os.release.foo')).to eq ''
+      expect(pfact_on(default, 'os.release.foo')).to eq ''
     end
   end
 
-  describe "pfact_on(master,'fips_enabled')" do
+  describe "pfact_on(default,'fips_enabled')" do
     expected = (ENV['BEAKER_fips'] == 'yes')
 
     it 'should return false' do
-      expect(pfact_on(master, 'fips_enabled')).to eq expected
+      expect(pfact_on(default, 'fips_enabled')).to eq expected
     end
   end
 
   describe "pfact_on returns a hash" do
     it 'should return a Hash' do
-      expect(pfact_on(master, 'os')).to be_a(Hash)
+      expect(pfact_on(default, 'os')).to be_a(Hash)
     end
   end
 end

--- a/spec/acceptance/suites/default/pki_tests_spec.rb
+++ b/spec/acceptance/suites/default/pki_tests_spec.rb
@@ -4,21 +4,21 @@ require 'tmpdir'
 
 context 'PKI operations' do
 
-  context 'after run_fake_pki_ca_on(master,hosts)' do
+  context 'after run_fake_pki_ca_on(default,hosts)' do
     before(:all) do
       copy_fixture_modules_to( hosts )
     end
 
     shared_examples_for 'a correctly copied keydist/ tree' do |test_dir|
       it 'correctly copies keydist/ tree' do
-        on(master, "ls -d #{test_dir}" +
+        on(default, "ls -d #{test_dir}" +
                    " #{test_dir}/cacerts" +
                    " #{test_dir}/cacerts/cacert_*.pem"
           )
 
         hosts.each do |host|
           name = host.node_name
-          on(master, "ls -d #{test_dir}/#{name}/cacerts" +
+          on(default, "ls -d #{test_dir}/#{name}/cacerts" +
                      " #{test_dir}/#{name}/#{name}.pem"  +
                      " #{test_dir}/#{name}/#{name}.pub"  +
                      " #{test_dir}/cacerts/cacert_*.pem"
@@ -29,10 +29,10 @@ context 'PKI operations' do
 
     describe 'a Fake CA under /root' do
       tmp_keydist_dir = Dir.mktmpdir 'simp-beaker-helpers__pki-tests'
-      run_fake_pki_ca_on( master, hosts, tmp_keydist_dir  )
+      run_fake_pki_ca_on( default, hosts, tmp_keydist_dir  )
 
       it 'should create /root/pki' do
-        on(master, 'test -d /root/pki')
+        on(default, 'test -d /root/pki')
       end
 
       it_behaves_like 'a correctly copied keydist/ tree', '/root/pki/keydist'
@@ -41,13 +41,13 @@ context 'PKI operations' do
 
     describe 'after copy_keydist_to' do
       test_dir = '/etc/puppetlabs/code/environments/production/modules/pki/files/keydist'
-      copy_keydist_to(master)
+      copy_keydist_to(default)
       it_behaves_like 'a correctly copied keydist/ tree', test_dir
     end
 
-    describe 'after copy_keydist_to(master,"/tmp/foo")' do
+    describe 'after copy_keydist_to(default,"/tmp/foo")' do
       test_dir = '/tmp/foo'
-      copy_keydist_to(master, test_dir)
+      copy_keydist_to(default, test_dir)
       it_behaves_like 'a correctly copied keydist/ tree', test_dir
     end
 


### PR DESCRIPTION
* Fixed:
  * Ensure that `multi_node` is enabled by default for backwards compatibility
  * Sort the discovered nodesets by default when running with `ALL` nodesets
