### PR TITLE
Limit the length of the CN in the template to 64 characters

### DIFF
--- a/files/pki/make.sh
+++ b/files/pki/make.sh
@@ -46,7 +46,7 @@ for hosts in $*; do
   echo "-- $hname"
   mkdir -p "${keydist}/${hname}/cacerts"
 
-  sed -e "s/#HOSTNAME#/${hname}/" template_host.cnf > "working/${hname}.cnf"
+  sed -e "s/#HOSTNAME#/${hname:0:63}/" template_host.cnf > "working/${hname}.cnf"
 
   if [ "$hname" != "$hosts" ];
   then


### PR DESCRIPTION
By definition, the CN of a request is a max of 64 bytes. Google internal hostnames can be longer than 64 bytes, which breaks the cert request generation

Fixes #193 