### PR TITLE
(#195) Allow not registrating subscription-manager

### DIFF
--- a/lib/simp/beaker_helpers.rb
+++ b/lib/simp/beaker_helpers.rb
@@ -643,7 +643,7 @@ module Simp::BeakerHelpers
             "https://dl.fedoraproject.org/pub/epel/epel-release-latest-#{os_maj_rel}.noarch.rpm",
           )
 
-          if os_info['name'] == 'RedHat' && env.fetch('BEAKER_RHSM_USER') && env.fetch('BEAKER_RHSM_PASS')
+          if os_info['name'] == 'RedHat' && ENV.fetch('BEAKER_RHSM_USER', false) && ENV.fetch('BEAKER_RHSM_PASS', false)
             if os_maj_rel == '7'
               on sut, %{subscription-manager repos --enable "rhel-*-optional-rpms"}
               on sut, %{subscription-manager repos --enable "rhel-*-extras-rpms"}
@@ -875,7 +875,7 @@ module Simp::BeakerHelpers
   end
 
   def rhel_repo_enable(suts, repos)
-    if env.fetch('BEAKER_RHSM_USER') && env.fetch('BEAKER_RHSM_PASS')
+    if ENV.fetch('BEAKER_RHSM_USER', false) && ENV.fetch('BEAKER_RHSM_PASS', false)
       block_on(suts, :run_in_parallel => @run_in_parallel) do |sut|
         Array(repos).each do |repo|
           on(sut, %{subscription-manager repos --enable #{repo}})
@@ -885,7 +885,7 @@ module Simp::BeakerHelpers
   end
 
   def rhel_repo_disable(suts, repos)
-    if env.fetch('BEAKER_RHSM_USER') && env.fetch('BEAKER_RHSM_PASS')
+    if ENV.fetch('BEAKER_RHSM_USER', false) && ENV.fetch('BEAKER_RHSM_PASS', false)
       block_on(suts, :run_in_parallel => @run_in_parallel) do |sut|
         Array(repos).each do |repo|
           on(sut, %{subscription-manager repos --disable #{repo}}, :accept_all_exit_codes => true)
@@ -895,7 +895,7 @@ module Simp::BeakerHelpers
   end
 
   def rhel_rhsm_unsubscribe(suts)
-    if env.fetch('BEAKER_RHSM_USER') && env.fetch('BEAKER_RHSM_PASS')
+    if ENV.fetch('BEAKER_RHSM_USER', false) && ENV.fetch('BEAKER_RHSM_PASS', false)
       block_on(suts, :run_in_parallel => @run_in_parallel) do |sut|
         on(sut, %{subscription-manager unregister}, :accept_all_exit_codes => true)
       end

--- a/lib/simp/beaker_helpers.rb
+++ b/lib/simp/beaker_helpers.rb
@@ -643,7 +643,7 @@ module Simp::BeakerHelpers
             "https://dl.fedoraproject.org/pub/epel/epel-release-latest-#{os_maj_rel}.noarch.rpm",
           )
 
-          if os_info['name'] == 'RedHat' && ENV.fetch('BEAKER_RHSM_USER', false) && ENV.fetch('BEAKER_RHSM_PASS', false)
+          if os_info['name'] == 'RedHat' && ENV['BEAKER_RHSM_USER'] && ENV['BEAKER_RHSM_PASS']
             if os_maj_rel == '7'
               on sut, %{subscription-manager repos --enable "rhel-*-optional-rpms"}
               on sut, %{subscription-manager repos --enable "rhel-*-extras-rpms"}
@@ -875,7 +875,7 @@ module Simp::BeakerHelpers
   end
 
   def rhel_repo_enable(suts, repos)
-    if ENV.fetch('BEAKER_RHSM_USER', false) && ENV.fetch('BEAKER_RHSM_PASS', false)
+    if ENV['BEAKER_RHSM_USER'] && ENV['BEAKER_RHSM_PASS']
       block_on(suts, :run_in_parallel => @run_in_parallel) do |sut|
         Array(repos).each do |repo|
           on(sut, %{subscription-manager repos --enable #{repo}})
@@ -885,7 +885,7 @@ module Simp::BeakerHelpers
   end
 
   def rhel_repo_disable(suts, repos)
-    if ENV.fetch('BEAKER_RHSM_USER', false) && ENV.fetch('BEAKER_RHSM_PASS', false)
+    if ENV['BEAKER_RHSM_USER'] && ENV['BEAKER_RHSM_PASS']
       block_on(suts, :run_in_parallel => @run_in_parallel) do |sut|
         Array(repos).each do |repo|
           on(sut, %{subscription-manager repos --disable #{repo}}, :accept_all_exit_codes => true)
@@ -895,7 +895,7 @@ module Simp::BeakerHelpers
   end
 
   def rhel_rhsm_unsubscribe(suts)
-    if ENV.fetch('BEAKER_RHSM_USER', false) && ENV.fetch('BEAKER_RHSM_PASS', false)
+    if ENV['BEAKER_RHSM_USER'] && ENV['BEAKER_RHSM_PASS']
       block_on(suts, :run_in_parallel => @run_in_parallel) do |sut|
         on(sut, %{subscription-manager unregister}, :accept_all_exit_codes => true)
       end

--- a/lib/simp/beaker_helpers.rb
+++ b/lib/simp/beaker_helpers.rb
@@ -643,7 +643,7 @@ module Simp::BeakerHelpers
             "https://dl.fedoraproject.org/pub/epel/epel-release-latest-#{os_maj_rel}.noarch.rpm",
           )
 
-          if os_info['name'] == 'RedHat'
+          if os_info['name'] == 'RedHat' && rhsm_opts[:username] && rhsm_opts[:password]
             if os_maj_rel == '7'
               on sut, %{subscription-manager repos --enable "rhel-*-optional-rpms"}
               on sut, %{subscription-manager repos --enable "rhel-*-extras-rpms"}
@@ -836,7 +836,8 @@ module Simp::BeakerHelpers
 
       if os == 'RedHat'
         unless rhsm_opts[:username] && rhsm_opts[:password]
-          fail("You must set BEAKER_RHSM_USER and BEAKER_RHSM_PASS environment variables to register RHEL systems")
+          warn("BEAKER_RHSM_USER and/or BEAKER_RHSM_PASS not set on RHEL system.", "Assuming that subscription-manager is not needed. This may prevent packages from installing")
+          return
         end
 
         sub_status = on(sut, 'subscription-manager status', :accept_all_exit_codes => true)
@@ -874,24 +875,30 @@ module Simp::BeakerHelpers
   end
 
   def rhel_repo_enable(suts, repos)
-    block_on(suts, :run_in_parallel => @run_in_parallel) do |sut|
-      Array(repos).each do |repo|
-        on(sut, %{subscription-manager repos --enable #{repo}})
+    if rhsm_opts[:username] && rhsm_opts[:password]
+      block_on(suts, :run_in_parallel => @run_in_parallel) do |sut|
+        Array(repos).each do |repo|
+          on(sut, %{subscription-manager repos --enable #{repo}})
+        end
       end
     end
   end
 
   def rhel_repo_disable(suts, repos)
-    block_on(suts, :run_in_parallel => @run_in_parallel) do |sut|
-      Array(repos).each do |repo|
-        on(sut, %{subscription-manager repos --disable #{repo}}, :accept_all_exit_codes => true)
+    if rhsm_opts[:username] && rhsm_opts[:password]
+      block_on(suts, :run_in_parallel => @run_in_parallel) do |sut|
+        Array(repos).each do |repo|
+          on(sut, %{subscription-manager repos --disable #{repo}}, :accept_all_exit_codes => true)
+        end
       end
     end
   end
 
   def rhel_rhsm_unsubscribe(suts)
-    block_on(suts, :run_in_parallel => @run_in_parallel) do |sut|
-      on(sut, %{subscription-manager unregister}, :accept_all_exit_codes => true)
+    if rhsm_opts[:username] && rhsm_opts[:password]
+      block_on(suts, :run_in_parallel => @run_in_parallel) do |sut|
+        on(sut, %{subscription-manager unregister}, :accept_all_exit_codes => true)
+      end
     end
   end
 

--- a/lib/simp/beaker_helpers.rb
+++ b/lib/simp/beaker_helpers.rb
@@ -643,7 +643,7 @@ module Simp::BeakerHelpers
             "https://dl.fedoraproject.org/pub/epel/epel-release-latest-#{os_maj_rel}.noarch.rpm",
           )
 
-          if os_info['name'] == 'RedHat' && rhsm_opts[:username] && rhsm_opts[:password]
+          if os_info['name'] == 'RedHat' && env.fetch('BEAKER_RHSM_USER') && env.fetch('BEAKER_RHSM_PASS')
             if os_maj_rel == '7'
               on sut, %{subscription-manager repos --enable "rhel-*-optional-rpms"}
               on sut, %{subscription-manager repos --enable "rhel-*-extras-rpms"}
@@ -875,7 +875,7 @@ module Simp::BeakerHelpers
   end
 
   def rhel_repo_enable(suts, repos)
-    if rhsm_opts[:username] && rhsm_opts[:password]
+    if env.fetch('BEAKER_RHSM_USER') && env.fetch('BEAKER_RHSM_PASS')
       block_on(suts, :run_in_parallel => @run_in_parallel) do |sut|
         Array(repos).each do |repo|
           on(sut, %{subscription-manager repos --enable #{repo}})
@@ -885,7 +885,7 @@ module Simp::BeakerHelpers
   end
 
   def rhel_repo_disable(suts, repos)
-    if rhsm_opts[:username] && rhsm_opts[:password]
+    if env.fetch('BEAKER_RHSM_USER') && env.fetch('BEAKER_RHSM_PASS')
       block_on(suts, :run_in_parallel => @run_in_parallel) do |sut|
         Array(repos).each do |repo|
           on(sut, %{subscription-manager repos --disable #{repo}}, :accept_all_exit_codes => true)
@@ -895,7 +895,7 @@ module Simp::BeakerHelpers
   end
 
   def rhel_rhsm_unsubscribe(suts)
-    if rhsm_opts[:username] && rhsm_opts[:password]
+    if env.fetch('BEAKER_RHSM_USER') && env.fetch('BEAKER_RHSM_PASS')
       block_on(suts, :run_in_parallel => @run_in_parallel) do |sut|
         on(sut, %{subscription-manager unregister}, :accept_all_exit_codes => true)
       end


### PR DESCRIPTION
Warn the user if the BEAKER_RHSM_USER/PASS aren't set, but allow them to continue. This should support pay-as-you-go cloud services.