### PR TITLE
Add GCP support to GLCI

### DIFF
--- a/.github/workflows/pr_glci.yml
+++ b/.github/workflows/pr_glci.yml
@@ -67,7 +67,7 @@ jobs:
     outputs:
       valid: ${{ steps.validate-glci-file.outputs.valid }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
@@ -80,11 +80,11 @@ jobs:
 
   contributor-permissions:
     name: 'PR contributor check'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     outputs:
       permitted: ${{ steps.user-repo-permissions.outputs.permitted }}
     steps:
-      - uses: actions/github-script@v3
+      - uses: actions/github-script@v6
         id: user-repo-permissions
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
@@ -135,7 +135,7 @@ jobs:
     #     - Not implemented: For some reason, this conditional always fails
     #     - Unnecessary if on>pull_request_target>types doesn't include 'closed'
     if: github.event_name == 'pull_request_target' && ( github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'synchronize' ) && github.event.pull_request.merged != 'true' && needs.glci-syntax.outputs.valid == 'true' && needs.contributor-permissions.outputs.permitted == 'true'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       # Things we'd like to do:
       # - [ ] if there's no GitLab mirror, make one
@@ -145,7 +145,7 @@ jobs:
       #       - "created|waiting_for_resource|preparing|pending|running"
       #       - Exception: don't cancel existing pipeline for our own commit
       # - [x] if PR: force-push branch to GitLab
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         if: needs.contributor-permissions.outputs.permitted == 'true'
         with:
           clean: true

--- a/.github/workflows/pr_glci_cleanup.yml
+++ b/.github/workflows/pr_glci_cleanup.yml
@@ -40,9 +40,9 @@ jobs:
     # `on` section is inadventently modified without considering the security
     # implications.
     if: github.event_name == 'pull_request_target' && github.event.action == 'closed'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/pr_glci_manual.yml
+++ b/.github/workflows/pr_glci_manual.yml
@@ -2,7 +2,7 @@
 # ------------------------------------------------------------------------------
 #
 #             NOTICE: **This file is maintained with puppetsync**
-#
+
 # This file is updated automatically as part of a standardized asset baseline.
 #
 # The next baseline sync will overwrite any local changes to this file!
@@ -42,7 +42,7 @@ on:
 jobs:
   glci-syntax:
     name: '.gitlab-ci.yml Syntax'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     outputs:
       valid: ${{ steps.validate-glci-file.outputs.valid }}
       pr_head_ref: ${{ steps.get-pr.outputs.pr_head_ref }}
@@ -50,7 +50,7 @@ jobs:
       pr_head_label: ${{ steps.get-pr.outputs.pr_head_label }}
       pr_head_full_name: ${{ steps.get-pr.outputs.pr_full_name }}
     steps:
-      - uses: actions/github-script@v3
+      - uses: actions/github-script@v6
         id: get-pr
         with:
           github-token: ${{secrets.NO_SCOPE_GITHUB_TOKEN}}
@@ -90,7 +90,7 @@ jobs:
             core.setOutput( 'pr_head_ref', pr.data.head.ref )
             core.setOutput( 'pr_head_label', pr.data.head.label )
             core.setOutput( 'pr_head_full_name', pr.data.head.full_name )
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: ${{ steps.get-pr.outputs.pr_head_full_name }}
           ref: ${{ steps.get-pr.outputs.pr_head_sha }}
@@ -106,9 +106,9 @@ jobs:
   trigger-when-user-has-repo-permissions:
     name: 'Trigger CI'
     needs: [ glci-syntax ]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: ${{ needs.glci-syntax.outputs.pr_head_full_name }}
           ref: ${{ needs.glci-syntax.outputs.pr_head_sha }}
@@ -129,7 +129,7 @@ jobs:
 ###    needs: [ glci-syntax ]
 ###    name: 'Examine Context contents'
 ###    if: always()
-###    runs-on: ubuntu-18.04
+###    runs-on: ubuntu-latest
 ###    steps:
 ###      - name: Dump contexts
 ###        env:

--- a/.github/workflows/tag_deploy_rubygem.yml
+++ b/.github/workflows/tag_deploy_rubygem.yml
@@ -63,7 +63,7 @@ jobs:
     steps:
       - name: "Assert '${{ github.ref }}' is a tag"
         run: '[[ "$GITHUB_REF" =~ ^refs/tags/ ]] || { echo "::error ::GITHUB_REF is not a tag: ${GITHUB_REF}"; exit 1 ; }'
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ github.ref }}
           clean: true
@@ -115,7 +115,7 @@ jobs:
       prerelease: ${{ steps.tag-check.outputs.prerelease }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.ref }}
           clean: true
@@ -177,7 +177,7 @@ jobs:
       PKG_DIR: ${{ needs.releng-checks.outputs.pkg_dir }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.ref }}
           clean: true


### PR DESCRIPTION
This patch updates GHA workflows to use GCP as a hypervisor when
BEAKER_HYPERVISOR is `google`

The patch enforces a standardized asset baseline using simp/puppetsync,
and may also apply other updates to ensure conformity.