### PR TITLE
Add GCP support to GLCI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,7 +25,7 @@ variables:
   # anchors.  If it is still `UNDEFINED`, all the other setting from the job's
   # anchor are also missing.
   PUPPET_VERSION:    'UNDEFINED' # <- Matrixed jobs MUST override this (or fail)
-  BUNDLER_VERSION:   '1.17.1'
+  BUNDLER_VERSION:   '2.2.19'
   SIMP_MATRIX_LEVEL: '1'
   SIMP_FORCE_RUN_MATRIX: 'no'
 
@@ -37,22 +37,24 @@ variables:
   BUNDLE_BIN:        .vendor/gem_install/bin
   BUNDLE_NO_PRUNE:   'true'
 
+.snippets:
+  before_beaker_google:
+    # Logic for beaker-google environments
+    - echo -e "\e[0Ksection_start:`date +%s`:before_script05[collapsed=true]\r\e[0KGCP environment checks"
+    - "if [ \"$BEAKER_HYPERVISOR\" ==  google ]; then mkdir -p ~/.ssh; chmod 700 ~/.ssh; test -f ~/.ssh/google_compute_engine || ssh-keygen -f ~/.ssh/google_compute_engine < /dev/null; echo 'gem \"beaker-google\"' >> Gemfile.local ; fi"
+    - echo -e "\e[0Ksection_end:`date +%s`:before_script05\r\e[0K"
 
-# bundler dependencies + caching, optional RVM setup, with diagnostic output
-# --------------------------------------------------------------------------
-.setup_bundler_env: &setup_bundler_env
-  cache:
-    # Cache bundler gems between pipelines for each Ruby version
-    key: "${CI_PROJECT_NAMESPACE}_ruby-${MATRIX_RUBY_VERSION}_bundler"
-    paths:
-      - '.vendor'
-  before_script:
-    - 'ruby -e "puts %(\n\n), %q(=)*80, %(\nSIMP-relevant Environment Variables:\n\n#{e=ENV.keys.grep(/^PUPPET|^SIMP|^BEAKER|MATRIX/); pad=e.map{|x| x.size}.max+1; e.map{|v| %(    * #{%(#{v}:).ljust(pad)} #{39.chr + ENV[v] + 39.chr}\n)}.join}\n),  %q(=)*80, %(\n\n)"'
+  before:
+    # Print important environment variables that may affect this job
+    - 'ruby -e "puts %(\n\n), %q(=)*80, %(\nSIMP-relevant Environment Variables:\n\n#{e=ENV.keys.grep(/^PUPPET|^SIMP|^BEAKER|MATRIX|GOOGLE/); pad=((e.map{|x| x.size}.max||0)+1); e.map{|v| %(    * #{%(#{v}:).ljust(pad)} #{39.chr + ENV[v] + 39.chr}\n)}.join}\n),  %q(=)*80, %(\n\n)" || :'
+
+    - echo -e "\e[0Ksection_start:`date +%s`:before_script10[collapsed=true]\r\e[0KDiagnostic ruby & gem information"
     # Diagnostic ruby & gem information
     - 'which ruby && ruby --version || :'
     - "[[ $- == *i* ]] && echo 'Interactive shell session' || echo 'Non-interactive shell session'"
     - "shopt -q login_shell && echo 'Login shell' || echo 'Not a login shell'"
     - 'rvm ls || :'
+    - echo -e "\e[0Ksection_end:`date +%s`:before_script10\r\e[0K"
 
     # If RVM is available, make SURE it's using the right Ruby:
     #   * Source rvm (to run in non-login shells)
@@ -64,22 +66,40 @@ variables:
     - "command -v rvm && { LATEST_RVM_RUBY_XY=\"$(rvm ls | grep \"$MATRIX_RUBY_VERSION\" | tail -1 | sed -e 's/^.*\\([0-9]\\+\\.[0-9]\\+\\.[0-9]\\+\\).*$/\\1/g')\"; if [ -z \"$LATEST_RVM_RUBY_XY\" ]; then LATEST_RVM_RUBY_XY=\"${MATRIX_RUBY_VERSION}-head\"; rvm install \"$LATEST_RVM_RUBY\" --no-docs; else echo \"Found RVM Ruby: '${LATEST_RVM_RUBY_XY}'\"; fi; rvm use \"$LATEST_RVM_RUBY_XY\" ;  }"
     - 'ruby --version || :'
     - 'gem list sync || :'
+    - echo -e "\e[0Ksection_end:`date +%s`:before_script20\r\e[0K"
 
     # Bundle gems (preferring cached > local > downloaded resources)
     #   * Try to use cached and local resources before downloading dependencies
-    - 'declare GEM_BUNDLER_VER=(-v "~> ${BUNDLER_VERSION:-1.17.1}")'
+    - echo -e "\e[0Ksection_start:`date +%s`:before_script30[collapsed=true]\r\e[0KBundle gems (preferring cached > local > downloaded resources)"
+    - 'declare GEM_BUNDLER_VER=(-v "~> ${BUNDLER_VERSION:-2.2.6}")'
     - 'declare GEM_INSTALL_CMD=(gem install --no-document)'
     - 'declare BUNDLER_INSTALL_CMD=(bundle install --no-binstubs --jobs $(nproc) "${FLAGS[@]}")'
     - 'mkdir -p ${GEM_HOME} ${BUNDLER_BIN}'
     - 'gem list -ie "${GEM_BUNDLER_VER[@]}" --silent bundler || "${GEM_INSTALL_CMD[@]}" --local "${GEM_BUNDLER_VER[@]}" bundler || "${GEM_INSTALL_CMD[@]}" "${GEM_BUNDLER_VER[@]}" bundler'
     - 'rm -rf pkg/ || :'
     - 'bundle check || rm -f Gemfile.lock && ("${BUNDLER_INSTALL_CMD[@]}" --local || "${BUNDLER_INSTALL_CMD[@]}" || bundle pristine ||  "${BUNDLER_INSTALL_CMD[@]}") || { echo "PIPELINE: Bundler could not install everything (see log output above)" && exit 99 ; }'
+    - echo -e "\e[0Ksection_end:`date +%s`:before_script30\r\e[0K"
 
     # Diagnostic bundler, ruby, and gem checks:
+    - echo -e "\e[0Ksection_start:`date +%s`:before_script40[collapsed=true]\r\e[0KDiagnostic bundler, ruby, and gem checks"
     - 'bundle exec rvm ls || :'
     - 'bundle exec which ruby || :'
     - 'bundle show sync || :'
     - 'bundle exec gem list sync || :'
+    - echo -e "\e[0Ksection_end:`date +%s`:before_script40\r\e[0K"
+
+# bundler dependencies and caching
+#
+# - Cache bundler gems between pipelines foreach Ruby version
+# - Try to use cached and local resources before downloading dependencies
+# --------------------------------------
+.setup_bundler_env: &setup_bundler_env
+  cache:
+    key: "${CI_PROJECT_NAMESPACE}_ruby-${MATRIX_RUBY_VERSION}_bundler"
+    paths:
+      - '.vendor'
+  before_script:
+    !reference [.snippets, before]
 
 
 # Assign a matrix level when your test will run.  Heavier jobs get higher numbers
@@ -219,7 +239,7 @@ variables:
 .pup_6_pe: &pup_6_pe
   image: 'ruby:2.5'
   variables:
-    PUPPET_VERSION: '6.18.0'
+    PUPPET_VERSION: '6.22.1'
     BEAKER_PUPPET_COLLECTION: 'puppet6'
     MATRIX_RUBY_VERSION: '2.5'
 
@@ -250,17 +270,27 @@ variables:
   script:
     - 'bundle exec rake spec'
 
+.beaker: &beaker
+  image: ruby:2.7.2  # must be 2.7.2 if running in GCP
+  tags:
+    - beaker
+  before_script:
+    - !reference [.snippets, before_beaker_google]
+    - !reference [.snippets, before]
+
+
+
 .acceptance_base: &acceptance_base
   stage: 'acceptance'
-  tags: ['beaker']
   <<: *setup_bundler_env
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_1
+  <<: *beaker
 
 .compliance_base: &compliance_base
   stage: 'compliance'
-  tags: ['beaker']
   <<: *setup_bundler_env
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_1
+  <<: *beaker
 
 
 # Unit Tests


### PR DESCRIPTION
This patch updates GHA workflows to use GCP as a hypervisor when
BEAKER_HYPERVISOR is `google`

The patch enforces a standardized asset baseline using simp/puppetsync,
and may also apply other updates to ensure conformity.