### PR TITLE
Replace puppetlabs_spec_helper with puppet_fixtures (Ruby 4.0 support)

### DIFF
--- a/.github/workflows/pr_acceptance.yml
+++ b/.github/workflows/pr_acceptance.yml
@@ -17,14 +17,6 @@ jobs:
     strategy:
       matrix:
         puppet:
-          - label: 'Puppet 7.x [SIMP 6.6/PE 2021.7]'
-            puppet_version: '~> 7.0'
-            ruby_version: '2.7'
-            experimental: false
-          - label: 'Puppet 8.x'
-            puppet_version: '~> 8.0'
-            ruby_version: '3.2'
-            experimental: false
           - label: 'OpenVox 8.x'
             puppet_version: '~> 8.0'
             ruby_version: '3.2'

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -48,13 +48,15 @@ jobs:
     strategy:
       matrix:
         puppet:
-          - label: 'Puppet 7.x [SIMP 6.6/PE 2021.7]'
-            puppet_version: '~> 7.0'
-            ruby_version: '2.7'
-            experimental: false
-          - label: 'Puppet 8.x'
+          - label: 'OpenVox 8.x'
             puppet_version: '~> 8.0'
             ruby_version: '3.2'
+            experimental: false
+          # OpenVox 9 is unreleased; preview the future Ruby 4.0 / OpenVox 9
+          # combo by running the OpenVox 8 gem on Ruby 4.0.
+          - label: 'OpenVox 9.x preview (Ruby 4.0, OpenVox 8 gem)'
+            puppet_version: '~> 8.0'
+            ruby_version: '4.0'
             experimental: false
     env:
       PUPPET_VERSION: ${{matrix.puppet.puppet_version}}

--- a/.github/workflows/tag_deploy_rubygem.yml
+++ b/.github/workflows/tag_deploy_rubygem.yml
@@ -48,7 +48,7 @@ on:
       - '[0-9]+\.[0-9]+\.[0-9]+\-[a-z]+[0-9]+'
 
 env:
-  PUPPET_VERSION: '~> 7'
+  PUPPET_VERSION: '~> 8'
   LOCAL_WORKFLOW_CONFIG_FILE: .github/workflows.local.json
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+### 3.0.0 / 2026-06-24
+* Changed (**Breaking**):
+  * Dropped support for Puppet 7 / Ruby 2.7. CI now tests Puppet/OpenVox 8 only,
+    and the default OpenVox gem floor is raised to `>= 8.0.0`.
+  * Replaced the `puppetlabs_spec_helper/tasks/fixtures` dependency with
+    `puppet_fixtures`, enabling Ruby 4.0 support. `puppetlabs_spec_helper` pulls
+    in `puppet-syntax` < 5, which depends on the `puppet` gem and its `facter`
+    dependency that does not support Ruby >= 4.0; `puppet_fixtures` is the
+    OpenVox-ecosystem replacement and supports Ruby 4.0.
+  * The `beaker:suites` task now depends on `fixtures:prep` (from
+    `puppet_fixtures`) instead of `spec_prep`, and `ensure_fixture_modules` now
+    runs `rake fixtures:prep`.
+* Added:
+  * `puppet_fixtures` runtime dependency
+  * OpenVox-named environment variables for `get_puppet_install_info`, taking
+    precedence over the Puppet-named equivalents (which remain as fallbacks):
+    `OPENVOX_VERSION`, `OPENVOX_INSTALL_VERSION`, `OPENVOX_INSTALL_TYPE`,
+    `BEAKER_OPENVOX_AGENT_VERSION`, `BEAKER_OPENVOX_COLLECTION`,
+    `BEAKER_OPENVOX_PACKAGE_NAME`
+
 ### 2.0.5 / 2026-06-06
 * Fixed:
   * Additional cleanup for rubocop

--- a/Gemfile
+++ b/Gemfile
@@ -41,9 +41,8 @@ group :system_tests do
   gem 'ed25519'
   gem 'net-ssh'
   # renovate: datasource=rubygems versioning=ruby
-  gem 'openvox', ENV.fetch('OPENVOX_VERSION', ENV.fetch('PUPPET_VERSION', ['>= 7.0.0', '< 9.0.0']))
+  gem 'openvox', ENV.fetch('OPENVOX_VERSION', ENV.fetch('PUPPET_VERSION', ['>= 8.0.0', '< 9.0.0']))
   gem 'pry-byebug', '~> 3.10.0'
-  gem 'puppetlabs_spec_helper', '>= 4.0.0', '< 9.0.0'
   gem 'syslog' # Required for Ruby >= 3.4
 end
 

--- a/lib/simp/beaker_helpers.rb
+++ b/lib/simp/beaker_helpers.rb
@@ -367,8 +367,8 @@ module Simp::BeakerHelpers # rubocop:disable Style/OneClassPerFile
       if missing_modules.empty?
         puts '  == all fixture modules present'
       else
-        cmd = 'bundle exec rake spec_prep'
-        puts "  -- running spec_prep: '#{cmd}'"
+        cmd = 'bundle exec rake fixtures:prep'
+        puts "  -- running fixtures:prep: '#{cmd}'"
         `#{cmd}`
       end
     end
@@ -1426,16 +1426,25 @@ module Simp::BeakerHelpers # rubocop:disable Style/OneClassPerFile
   #       install version and a puppet collection are specified. This is
   #       because the puppet install version can specify more precise
   #       version information than is available from a puppet collection.
+  #
+  #       Each Puppet-named environment variable has an OpenVox-named
+  #       equivalent (e.g. OPENVOX_VERSION, BEAKER_OPENVOX_COLLECTION) that
+  #       takes precedence; the Puppet-named variables are kept as fallbacks
+  #       for backwards compatibility.
   def get_puppet_install_info
-    # The first match is internal Beaker and the second is legacy SIMP
-    puppet_install_version = ENV['BEAKER_PUPPET_AGENT_VERSION'] || ENV['PUPPET_INSTALL_VERSION'] || ENV['PUPPET_VERSION']
+    # OpenVox-named variables win; the Puppet-named ones remain as fallbacks.
+    # Within each pair the first match is internal Beaker, the second legacy SIMP.
+    puppet_install_version =
+      ENV['BEAKER_OPENVOX_AGENT_VERSION'] || ENV['BEAKER_PUPPET_AGENT_VERSION'] ||
+      ENV['OPENVOX_INSTALL_VERSION'] || ENV['PUPPET_INSTALL_VERSION'] ||
+      ENV['OPENVOX_VERSION'] || ENV['PUPPET_VERSION']
 
     if puppet_install_version && !puppet_install_version.strip.empty?
       puppet_agent_version = latest_puppet_agent_version_for(puppet_install_version.strip)
     end
 
     if puppet_agent_version.nil?
-      if (puppet_collection = ENV['BEAKER_PUPPET_COLLECTION'] || host.options['puppet_collection'])
+      if (puppet_collection = ENV['BEAKER_OPENVOX_COLLECTION'] || ENV['BEAKER_PUPPET_COLLECTION'] || host.options['puppet_collection'])
         raise("Error: Puppet Collection '#{puppet_collection}' must match /(puppet|openvox)(\\d+)/") unless puppet_collection =~ %r{(puppet|openvox)(\d+)}
         puppet_collection_name = ::Regexp.last_match(1)
         puppet_install_version = "~> #{::Regexp.last_match(2)}"
@@ -1453,18 +1462,18 @@ module Simp::BeakerHelpers # rubocop:disable Style/OneClassPerFile
     {
       puppet_install_version: puppet_agent_version,
       puppet_collection: puppet_collection,
-      puppet_install_type: ENV.fetch('PUPPET_INSTALL_TYPE', 'agent')
+      puppet_install_type: ENV['OPENVOX_INSTALL_TYPE'] || ENV.fetch('PUPPET_INSTALL_TYPE', 'agent')
     }
   end
 
   def run_puppet_install_helper_on(hosts)
     block_on hosts, run_in_parallel: true do |host|
-      puppet_collection = ENV.fetch('BEAKER_PUPPET_COLLECTION', nil) || host.options['puppet_collection']
+      puppet_collection = ENV['BEAKER_OPENVOX_COLLECTION'] || ENV.fetch('BEAKER_PUPPET_COLLECTION', nil) || host.options['puppet_collection']
       if is_windows?(host)
         install_msi_on(host, puppet_collection)
       else
         BeakerPuppetHelpers::InstallUtils.install_puppet_release_repo_on(host, puppet_collection)
-        package_name = ENV.fetch('BEAKER_PUPPET_PACKAGE_NAME', BeakerPuppetHelpers::InstallUtils.collection2packagename(host, puppet_collection))
+        package_name = ENV['BEAKER_OPENVOX_PACKAGE_NAME'] || ENV.fetch('BEAKER_PUPPET_PACKAGE_NAME', BeakerPuppetHelpers::InstallUtils.collection2packagename(host, puppet_collection))
         host.install_package(package_name)
       end
     end

--- a/lib/simp/beaker_helpers/version.rb
+++ b/lib/simp/beaker_helpers/version.rb
@@ -4,5 +4,5 @@
 module Simp; end
 
 module Simp::BeakerHelpers # rubocop:disable Style/OneClassPerFile
-  VERSION = '2.0.5'
+  VERSION = '3.0.0'
 end

--- a/lib/simp/rake/beaker.rb
+++ b/lib/simp/rake/beaker.rb
@@ -4,7 +4,7 @@ require 'rake/tasklib'
 require 'fileutils'
 require 'beaker/tasks/rake_task'
 require 'beaker-rspec/rake_task'
-require 'puppetlabs_spec_helper/tasks/fixtures'
+require 'puppet_fixtures/tasks'
 
 # Simp namespace
 module Simp; end
@@ -111,7 +111,7 @@ class Simp::Rake::Beaker < ::Rake::TaskLib # rubocop:disable Style/OneClassPerFi
               'default_run' : <true|false> => Default: false
               ```
         EOM
-      task :suites, [:suite, :nodeset] => ['spec_prep'] do |_t, args|
+      task :suites, [:suite, :nodeset] => ['fixtures:prep'] do |_t, args|
         suite = args[:suite]
         nodeset = args[:nodeset]
 

--- a/simp-beaker-helpers.gemspec
+++ b/simp-beaker-helpers.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'docker-api',            ['>= 2.1.0', '< 3.0.0']
   s.add_runtime_dependency 'highline',              ['>= 2.0', '< 4.0.0']
   s.add_runtime_dependency 'nokogiri',              '~> 1.8'
+  s.add_runtime_dependency 'puppet_fixtures',       ['>= 0.1', '< 3.0.0']
 
   ### s.files = Dir['Rakefile', '{bin,lib,spec}/**/*', 'README*', 'LICENSE*'] & `git ls-files -z .`.split("\0")
   s.files       = %x(git ls-files).split("\n")

--- a/spec/lib/simp/beaker_helpers_spec.rb
+++ b/spec/lib/simp/beaker_helpers_spec.rb
@@ -131,10 +131,15 @@ describe 'Simp::BeakerHelpers' do
 
   context '#get_puppet_install_info' do
     after(:each) do
+      ENV['BEAKER_OPENVOX_AGENT_VERSION'] = nil
       ENV['BEAKER_PUPPET_AGENT_VERSION'] = nil
+      ENV['OPENVOX_INSTALL_VERSION'] = nil
       ENV['PUPPET_INSTALL_VERSION'] = nil
+      ENV['OPENVOX_VERSION'] = nil
       ENV['PUPPET_VERSION'] = nil
+      ENV['BEAKER_OPENVOX_COLLECTION'] = nil
       ENV['BEAKER_PUPPET_COLLECTION'] = nil
+      ENV['OPENVOX_INSTALL_TYPE'] = nil
       ENV['PUPPET_INSTALL_TYPE'] = nil
     end
 
@@ -220,6 +225,46 @@ describe 'Simp::BeakerHelpers' do
         puppet_install_type: 'agent'
       }
       expect(helper.get_puppet_install_info).to eq expected
+    end
+
+    it 'extracts info from OPENVOX_VERSION' do
+      allow(helper).to receive(:`).with('gem search -ra -e puppet').and_return(gem_search_results)
+      ENV['OPENVOX_VERSION'] = '5.5.0'
+      expected = {
+        puppet_install_version: '5.5.0',
+        puppet_collection: 'puppet5',
+        puppet_install_type: 'agent'
+      }
+      expect(helper.get_puppet_install_info).to eq expected
+    end
+
+    it 'extracts openvox info from BEAKER_OPENVOX_COLLECTION' do
+      allow(helper).to receive(:`).with('gem search -ra -e openvox').and_return(openvox_gem_search_results)
+      ENV['BEAKER_OPENVOX_COLLECTION'] = 'openvox8'
+      expected = {
+        puppet_install_version: '8.19.2',
+        puppet_collection: 'openvox8',
+        puppet_install_type: 'agent'
+      }
+      expect(helper.get_puppet_install_info).to eq expected
+    end
+
+    it 'prefers BEAKER_OPENVOX_COLLECTION over BEAKER_PUPPET_COLLECTION' do
+      allow(helper).to receive(:`).with('gem search -ra -e openvox').and_return(openvox_gem_search_results)
+      ENV['BEAKER_OPENVOX_COLLECTION'] = 'openvox8'
+      ENV['BEAKER_PUPPET_COLLECTION'] = 'puppet5'
+      expected = {
+        puppet_install_version: '8.19.2',
+        puppet_collection: 'openvox8',
+        puppet_install_type: 'agent'
+      }
+      expect(helper.get_puppet_install_info).to eq expected
+    end
+
+    it 'extracts info from OPENVOX_INSTALL_TYPE' do
+      ENV['OPENVOX_INSTALL_TYPE'] = 'pe'
+
+      expect(helper.get_puppet_install_info[:puppet_install_type]).to eq('pe')
     end
 
     it 'extracts info from PUPPET_INSTALL_TYPE' do


### PR DESCRIPTION
simp-beaker-helpers required `puppetlabs_spec_helper/tasks/fixtures` for its fixture rake tasks. puppetlabs_spec_helper pulls in puppet-syntax < 5, which depends on the `puppet` gem and its `facter` dependency, and `facter` does not support Ruby >= 4.0 -- so anything depending on simp-beaker-helpers (e.g. simp-rake-helpers) could not run on Ruby 4.

Switch to `puppet_fixtures`, the OpenVox-ecosystem fixtures gem (used by voxpupuli-test), which supports Ruby 4.0:

- beaker.rb: require 'puppet_fixtures/tasks'; the beaker:suites task depends on 'fixtures:prep' instead of 'spec_prep'
- beaker_helpers.rb: ensure_fixture_modules runs 'rake fixtures:prep'
- Declare puppet_fixtures as a runtime dependency
- Drop the dev puppetlabs_spec_helper from the Gemfile

Verified: specs pass and the fixtures:prep/fixtures:clean/beaker:suites tasks load on Ruby 3.2 and Ruby 4.0.