### PR TITLE
Run ensure_beaker_ip_on before FakeCA collects cert SAN addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+### 3.1.1 / 2026-07-03
+* Fixed:
+  * `run_fake_pki_ca_on` now runs `ensure_beaker_ip_on` before collecting
+    the IP addresses embedded in certificate subjectAltNames, so certs match
+    the corrected (Beaker-recorded) addresses on SUTs where the static
+    private-network IP was never applied (e.g. EL10 under Vagrant). Without
+    this, IKE peer IDs no longer match the cert SANs after remediation and
+    strict validators (libreswan 5) reject authentication.
+
 ### 3.1.0 / 2026-07-02
 * Added:
   * `ensure_beaker_ip_on`: detect SUTs whose recorded `host[:ip]` was never

--- a/lib/simp/beaker_helpers.rb
+++ b/lib/simp/beaker_helpers.rb
@@ -976,6 +976,13 @@ module Simp::BeakerHelpers # rubocop:disable Style/OneClassPerFile
       # Ensure that all interfaces are active prior to collecting data
       activate_interfaces(host)
 
+      # Ensure the Beaker-recorded IP is actually applied before it is
+      # embedded in certificate subjectAltNames (on EL10 under Vagrant the
+      # static private-network IP is silently never applied and the
+      # interface falls back to DHCP; certs cut from the DHCP address no
+      # longer match the peer IDs once the address is corrected)
+      ensure_beaker_ip_on(host)
+
       networking_fact = pfact_on(host, 'networking')
       if networking_fact && networking_fact['interfaces']
         networking_fact['interfaces'].each_value do |data|

--- a/lib/simp/beaker_helpers/version.rb
+++ b/lib/simp/beaker_helpers/version.rb
@@ -4,5 +4,5 @@
 module Simp; end
 
 module Simp::BeakerHelpers # rubocop:disable Style/OneClassPerFile
-  VERSION = '3.1.0'
+  VERSION = '3.1.1'
 end


### PR DESCRIPTION
Follow-up to #284. `run_fake_pki_ca_on` embeds the SUTs' live IPs in cert subjectAltNames — but it can run (e.g. from a `before(:suite)` hook, as pupmod-simp-libreswan does) **before** the `before(:all)` hook that applies `ensure_beaker_ip_on`. On EL10/Vagrant SUTs the certs were then cut from the transient DHCP address; after remediation, IKE peer IDs no longer matched the cert SANs and libreswan 5 (strict ID-vs-SAN matching) rejected auth with `AUTHENTICATION_FAILED`.

Fix: correct the address inside `run_fake_pki_ca_on`, right next to the existing `activate_interfaces` call, before SAN data is collected. Version 3.1.1 + CHANGELOG.

Diagnosed on a live left/right almalinux10 pair: cert SAN said `IP:10.254.16.168` (pre-fix DHCP) while the wire IP was the corrected `10.254.188.154`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)